### PR TITLE
[WIP] Cache resource dictionaries

### DIFF
--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -273,6 +273,8 @@ def update_lookup_table():
     lookup_table["synonyms"] = get_resource_dict("SynLex.csv")
     lookup_table["abbreviations"] = get_resource_dict("AbbLex.csv")
     lookup_table["abbreviation_lower"] = get_resource_dict("AbbLex.csv", True)
+    lookup_table["non_english_words"] = get_resource_dict("NefLex.csv")
+    lookup_table["non_english_words_lower"] = get_resource_dict("NefLex.csv", True)
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
         # Write lookup_table in JSON format
@@ -347,10 +349,6 @@ def run(args):
     resource_terms_revised = {}
     resource_terms_ID_based = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-
-    # 13-Get all Non English Language words mappings from resource in CSV file format and put in a dictionary to be used further
-    non_english_words = get_resource_dict("NefLex.csv")
-    non_english_words_lower = get_resource_dict("NefLex.csv", True)
 
     # 14-Get all spelling mistake examples from resource in CSV file format and put in a dictionary to be used further
     spelling_mistakes = get_resource_dict("ScorLex.csv")
@@ -524,11 +522,11 @@ def run(args):
                 lemma = lookup_table["abbreviation_lower"][lemma.lower()]
                 status_addendum.append("Change Case and Abbreviation-Acronym Treatment")
 
-            if (lemma in non_english_words.keys()):  # Non English language words taken care of
-                lemma = non_english_words[lemma]
+            if (lemma in lookup_table["non_english_words"].keys()):  # Non English language words taken care of
+                lemma = lookup_table["non_english_words"][lemma]
                 status_addendum.append("Non English Language Words Treatment")
-            elif (lemma.lower() in non_english_words_lower.keys()):
-                lemma = non_english_words_lower[lemma.lower()]
+            elif (lemma.lower() in lookup_table["non_english_words_lower"].keys()):
+                lemma = lookup_table["non_english_words_lower"][lemma.lower()]
                 status_addendum.append("Change Case and Non English Language Words Treatment")
 
 
@@ -551,8 +549,8 @@ def run(args):
             if (cleaned_sample in non_english_words.keys()):  # non English words taken care of
                 cleaned_sample = non_english_words[cleaned_sample]
                 status_addendum.append("Cleaned Sample and Non English Language Words Treatment")
-            elif (cleaned_sample in non_english_words_lower.keys()):
-                cleaned_sample = non_english_words_lower[cleaned_sample]
+            elif (cleaned_sample in lookup_table["non_english_words_lower"].keys()):
+                cleaned_sample = lookup_table["non_english_words_lower"][cleaned_sample]
                 status_addendum.append("Cleaned Sample and Non English Language Words Treatment")
 
         # Here we are making the tokens of cleaned sample phrase
@@ -917,8 +915,8 @@ def run(args):
                     if (grm in lookup_table["abbreviations"].keys()):  # rule for abbreviation
                         grm = lookup_table["abbreviations"][grm]
                         status_addendum.append("Abbreviation-Acronym Treatment")
-                    if (grm in non_english_words.keys()):  # rule for abbreviation
-                        grm = non_english_words[grm]
+                    if (grm in lookup_table["non_english_words"].keys()):  # rule for abbreviation
+                        grm = lookup_table["non_english_words"][grm]
                         status_addendum.append("Non English Language Words Treatment")
                     if (grm in lookup_table["synonyms"].keys()):  ## Synonyms taken care of- need more synonyms
                         grm = lookup_table["synonyms"][grm]
@@ -977,8 +975,8 @@ def run(args):
                     if (grm in lookup_table["abbreviations"].keys()):  # rule for abbreviation
                         grm = lookup_table["abbreviations"][grm]
                         status_addendum.append("Abbreviation-Acronym Treatment")
-                    if (grm in non_english_words.keys()):  # rule for abbreviation
-                        grm = non_english_words[grm]
+                    if (grm in lookup_table["non_english_words"].keys()):  # rule for abbreviation
+                        grm = lookup_table["non_english_words"][grm]
                         status_addendum.append("Non English Language Words Treatment")
                     if (grm in lookup_table["synonyms"].keys()):  ## Synonyms taken care of- need more synonyms
                         grm = lookup_table["synonyms"][grm]
@@ -1038,8 +1036,8 @@ def run(args):
                     if (grm in lookup_table["abbreviations"].keys()):  # rule for abbreviation
                         grm = lookup_table["abbreviations"][grm]
                         status_addendum.append("Abbreviation-Acronym Treatment")
-                    if (grm in non_english_words.keys()):  # rule for abbreviation
-                        grm = non_english_words[grm]
+                    if (grm in lookup_table["non_english_words"].keys()):  # rule for abbreviation
+                        grm = lookup_table["non_english_words"][grm]
                         status_addendum.append("Non English Language Words Treatment")
                     if (grm in lookup_table["synonyms"].keys()):  ## Synonyms taken care of- need more synonyms
                         grm = lookup_table["synonyms"][grm]
@@ -1109,8 +1107,8 @@ def run(args):
                     if (grm in lookup_table["abbreviations"].keys()):  # rule for abbreviation
                         grm = lookup_table["abbreviations"][grm]
                         status_addendum.append("Abbreviation-Acronym Treatment")
-                    if (grm in non_english_words.keys()):  # rule for abbreviation
-                        grm = non_english_words[grm]
+                    if (grm in lookup_table["non_english_words"].keys()):  # rule for abbreviation
+                        grm = lookup_table["non_english_words"][grm]
                         status_addendum.append("Non English Language Words Treatment")
                     if (grm in lookup_table["synonyms"].keys()):  ## Synonyms taken care of- need more synonyms
                         grm = lookup_table["synonyms"][grm]
@@ -1179,8 +1177,8 @@ def run(args):
                 if (grm in lookup_table["abbreviations"].keys()):  # rule for abbreviation
                     grm = lookup_table["abbreviations"][grm]
                     status_addendum.append("Abbreviation-Acronym Treatment")
-                if (grm in non_english_words.keys()):  # rule for abbreviation
-                    grm = non_english_words[grm]
+                if (grm in lookup_table["non_english_words"].keys()):  # rule for abbreviation
+                    grm = lookup_table["non_english_words"][grm]
                     status_addendum.append("Non English Language Words Treatment")
                 if (grm in lookup_table["synonyms"].keys()):  ## Synonyms taken care of- need more synonyms
                     grm = lookup_table["synonyms"][grm]

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -281,6 +281,7 @@ def update_lookup_table():
     lookup_table["qualities"] = get_resource_dict("SemLex.csv")
     lookup_table["qualities_lower"] = get_resource_dict("SemLex.csv", True)
     lookup_table["collocations"] = get_resource_dict("wikipediaCollocations.csv")
+    lookup_table["inflection_exceptions"] = get_resource_dict("inflection-exceptions.csv", True)
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
         # Write lookup_table in JSON format
@@ -355,9 +356,6 @@ def run(args):
     resource_terms_revised = {}
     resource_terms_ID_based = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-
-    # 18-Method to get all inflection exception words from resource in CSV file format -Needed to supercede the general inflection treatment
-    inflection_exceptions = get_resource_dict("inflection-exceptions.csv", True)
     
     # 19-Method to Get all stop words from resource in CSV file format -A very constrained lists of stop words is
     # used as other stop words are assumed to have some useful semantic meaning
@@ -493,7 +491,7 @@ def run(args):
             # Plurals are converted to singulars with exceptions
             if (tkn.endswith("us") or tkn.endswith("ia") or tkn.endswith("ta")):  # for inflection exception in general-takes into account both lower and upper case (apart from some inflection-exception list used also in next
                 lemma = tkn
-            elif (tkn not in inflection_exceptions):  # Further Inflection Exception list is taken into account
+            elif (tkn not in lookup_table["inflection_exceptions"]):  # Further Inflection Exception list is taken into account
                 lemma = inflection.singularize(tkn)
                 if (tkn != lemma):  #Only in case when inflection makes some changes in lemma
                     status_addendum.append("Inflection (Plural) Treatment")

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -275,6 +275,8 @@ def update_lookup_table():
     lookup_table["abbreviation_lower"] = get_resource_dict("AbbLex.csv", True)
     lookup_table["non_english_words"] = get_resource_dict("NefLex.csv")
     lookup_table["non_english_words_lower"] = get_resource_dict("NefLex.csv", True)
+    lookup_table["spelling_mistakes"] = get_resource_dict("ScorLex.csv")
+    lookup_table["spelling_mistakes_lower"] = get_resource_dict("ScorLex.csv", True)
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
         # Write lookup_table in JSON format
@@ -349,10 +351,6 @@ def run(args):
     resource_terms_revised = {}
     resource_terms_ID_based = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-
-    # 14-Get all spelling mistake examples from resource in CSV file format and put in a dictionary to be used further
-    spelling_mistakes = get_resource_dict("ScorLex.csv")
-    spelling_mistakes_lower = get_resource_dict("ScorLex.csv", True)
 
     # 15-Get candidate processes from resource in a CSV file format and put in a dictionary to be used further
     processes = get_resource_dict("candidateProcesses.csv")
@@ -509,11 +507,11 @@ def run(args):
                 lemma = tkn
 
             # Misspellings are dealt with  here
-            if (lemma in spelling_mistakes.keys()):  # spelling mistakes taken care of
-                lemma = spelling_mistakes[lemma]
+            if (lemma in lookup_table["spelling_mistakes"].keys()):  # spelling mistakes taken care of
+                lemma = lookup_table["spelling_mistakes"][lemma]
                 status_addendum.append("Spelling Correction Treatment")
-            elif (lemma.lower() in spelling_mistakes_lower.keys()):
-                lemma = spelling_mistakes_lower[lemma.lower()]
+            elif (lemma.lower() in lookup_table["spelling_mistakes_lower"].keys()):
+                lemma = lookup_table["spelling_mistakes_lower"][lemma.lower()]
                 status_addendum.append("Change Case and Spelling Correction Treatment")
             if (lemma in lookup_table["abbreviations"].keys()):  # Abbreviations, acronyms, foreign language words taken care of- need rule for abbreviation e.g. if lemma is Abbreviation
                 lemma = lookup_table["abbreviations"][lemma]

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -355,21 +355,8 @@ def load_lookup_table():
     """
     # lookup_table.json exists
     if os.path.isfile("lookup_table.json"):
-        # last modification time of lookup_table.json
-        lookup_table_modification_time = os.path.getmtime("lookup_table.json")
-
-        # list of all file names in resources folder
-        resource_names = [file_name for file_name in os.listdir(get_path("resources"))]
-        # list of paths to all files in resources folder
-        resource_paths = [get_path(file_name, "resources/") for file_name in resource_names]
-        # list of last modification times for files in resources folder
-        resources_files_modification_times = [os.path.getmtime(path) for path in resource_paths]
-        # most recent modification time of a file in resources folder
-        resources_folder_modification_time = max(resources_files_modification_times)
-
-        # resources modified more recently than lookup_table.json
-        if resources_folder_modification_time > lookup_table_modification_time:
-            # update lookup_table
+        # lookup_table.json out of date
+        if is_lookup_table_outdated():
             update_lookup_table()
     # lookup_table.json does not exist
     else:
@@ -391,15 +378,30 @@ def get_path(file_name, prefix=""):
     """
     return os.path.join(os.path.dirname(__file__), prefix+file_name)
 
+def is_lookup_table_outdated():
+    """...WIP"""
+    # last modification time of lookup_table.json
+    lookup_table_modification_time = os.path.getmtime("lookup_table.json")
+
+    # list of all file names in resources folder
+    resource_names = [file_name for file_name in os.listdir(get_path("resources"))]
+    # list of paths to all files in resources folder
+    resource_paths = [get_path(file_name, "resources/") for file_name in resource_names]
+    # list of last modification times for files in resources folder
+    resources_files_modification_times = [os.path.getmtime(path) for path in resource_paths]
+    # most recent modification time of a file in resources folder
+    resources_folder_modification_time = max(resources_files_modification_times)
+
+    # resources modified more recently than lookup_table.json
+    if resources_folder_modification_time > lookup_table_modification_time:
+        return True
+    else:
+        return False
+
 def run(args):
     """
     Main text mining pipeline.
     """
-    # TODO: remove this later
-    # update_lookup_table()
-    load_lookup_table()
-    # # print(lookup_table)
-    # sys.exit()
     punctuations = ['-', '_', '(', ')', ';', '/', ':', '%']  # Current punctuations for basic treatment
     covered_tokens = []
     remainingAllTokensSet = []
@@ -409,7 +411,10 @@ def run(args):
     samplesList = []
     samplesSet = []
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-                    
+
+    # Load global lookup_table variable from cache
+    load_lookup_table()
+
     # Output file Column Headings
     OUTPUT_FIELDS = [
         "Sample_Id",

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -284,6 +284,8 @@ def update_lookup_table():
     lookup_table["inflection_exceptions"] = get_resource_dict("inflection-exceptions.csv", True)
     lookup_table["stop_words"] = get_resource_dict("mining-stopwords.csv", True)
     lookup_table["resource_terms_ID_based"] = get_resource_dict("CombinedResourceTerms.csv")
+    # TODO: reduce line length
+    lookup_table["resource_terms"] = {v:k for k,v in lookup_table["resource_terms_ID_based"].items()}
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
         # Write lookup_table in JSON format
@@ -354,14 +356,11 @@ def run(args):
     samplesDict = collections.OrderedDict()
     samplesList = []
     samplesSet = []
-    resource_terms = {}
     resource_terms_revised = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
 
-    # Swap keys and values in resource_terms_ID_based
-    resource_terms = {v:k for k,v in lookup_table["resource_terms_ID_based"].items()}
     # Convert keys in resource_terms to lowercase
-    resource_terms_revised = {k.lower():v for k,v in resource_terms.items()}
+    resource_terms_revised = {k.lower():v for k,v in lookup_table["resource_terms"].items()}
 
     # 23-Method for getting all the permutations of Resource Terms
     resource_permutation_terms = {}
@@ -646,21 +645,21 @@ def run(args):
                 # Return
                 return ret
             # Full-term match without any treatment
-            elif sample in resource_terms:
+            elif sample in lookup_table["resource_terms"]:
                 # Term with we found a full-term match for
                 matched_term = sample
                 # Resource ID for matched_term
-                resource_id = resource_terms[matched_term]
+                resource_id = lookup_table["resource_terms"][matched_term]
                 # Update retained_tokens
                 retained_tokens.append(matched_term + ":" + resource_id)
                 # Update status_addendum
                 status_addendum.append("A Direct Match")
             # Full-term match with change-of-case in input data
-            elif sample.lower() in resource_terms:
+            elif sample.lower() in lookup_table["resource_terms"]:
                 # Term with we found a full-term match for
                 matched_term = sample.lower()
                 # Resource ID for matched_term
-                resource_id = resource_terms[matched_term]
+                resource_id = lookup_table["resource_terms"][matched_term]
                 # Update retained_tokens
                 retained_tokens.append(matched_term + ":" + resource_id)
                 # Update status_addendum
@@ -705,11 +704,11 @@ def run(args):
                 status_addendum.append(
                     "Permutation of Tokens in Bracketed Resource Term")
             # Full-term cleaned sample match without any treatment
-            elif cleaned_sample.lower() in resource_terms:
+            elif cleaned_sample.lower() in lookup_table["resource_terms"]:
                 # Term with we found a full-term match for
                 matched_term = cleaned_sample.lower()
                 # Resource ID for matched_term
-                resource_id = resource_terms[matched_term]
+                resource_id = lookup_table["resource_terms"][matched_term]
                 # Update retained_tokens
                 retained_tokens.append(matched_term + ":" + resource_id)
                 # Update status_addendum
@@ -908,7 +907,7 @@ def run(args):
                         status_addendum.append("Synonym Usage")
 
                     # Matching Test for 5-gram chunk
-                    if ((grm in resource_terms.keys() ) and not localTrigger):
+                    if ((grm in lookup_table["resource_terms"].keys() ) and not localTrigger):
                         partialMatchedList.append(grm)
                         for eachTkn in grmTokens:
                             covered_tokens.append(eachTkn)
@@ -968,7 +967,7 @@ def run(args):
                         status_addendum.append("Synonym Usage")
 
                     # Matching Test for 4-gram chunk
-                    if ((grm in resource_terms.keys()) and not localTrigger):
+                    if ((grm in lookup_table["resource_terms"].keys()) and not localTrigger):
                         partialMatchedList.append(grm)
                         for eachTkn in grmTokens:
                             covered_tokens.append(eachTkn)
@@ -1029,7 +1028,7 @@ def run(args):
                         status_addendum.append("Synonym Usage")
 
                     # Matching Test for 3-gram chunk
-                    if ((grm in resource_terms.keys() ) and not localTrigger):
+                    if ((grm in lookup_table["resource_terms"].keys() ) and not localTrigger):
                         partialMatchedList.append(grm)
                         for eachTkn in grmTokens:
                             covered_tokens.append(eachTkn)
@@ -1100,7 +1099,7 @@ def run(args):
                         status_addendum.append("Synonym Usage")
 
                     # Matching Test for 2-gram chunk
-                    if ((grm in resource_terms.keys() ) and not localTrigger):
+                    if ((grm in lookup_table["resource_terms"].keys() ) and not localTrigger):
                         partialMatchedList.append(grm)
                         for eachTkn in grmTokens:
                             covered_tokens.append(eachTkn)
@@ -1170,7 +1169,7 @@ def run(args):
                     status_addendum.append("Synonym Usage")
 
                 # Matching Test for 1-gram chunk
-                if ((grm in resource_terms.keys() ) and not localTrigger):
+                if ((grm in lookup_table["resource_terms"].keys() ) and not localTrigger):
                     partialMatchedList.append(grm)
                     for eachTkn in grmTokens:
                         covered_tokens.append(eachTkn)
@@ -1253,8 +1252,8 @@ def run(args):
 
             #Decoding the partial matched set to get back resource ids
             for matchstring in partialMatchedSet:
-                if (matchstring in resource_terms.keys()):
-                    resourceId = resource_terms[matchstring]
+                if (matchstring in lookup_table["resource_terms"].keys()):
+                    resourceId = lookup_table["resource_terms"][matchstring]
                     partialMatchedResourceList.append(matchstring + ":" + resourceId)
                 elif (matchstring in resource_terms_revised.keys()):
                     resourceId = resource_terms_revised[matchstring]

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -335,7 +335,17 @@ def get_path(file_name, prefix=""):
     return os.path.join(os.path.dirname(__file__), prefix+file_name)
 
 def is_lookup_table_outdated():
-    """...WIP"""
+    """Returns True if lookup_table.json is outdated.
+
+    lookup_table.json is considered outdated if it has an older last
+    modification time than any file in /resources.
+
+    Return values:
+        * <class "bool">: Indicates whether lookup_table.json is
+            outdated.
+    Restrictions:
+        * should only be called if lookup_table.json exists
+    """
     # last modification time of lookup_table.json
     lookup_table_modification_time = os.path.getmtime("lookup_table.json")
 

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -283,6 +283,7 @@ def update_lookup_table():
     lookup_table["collocations"] = get_resource_dict("wikipediaCollocations.csv")
     lookup_table["inflection_exceptions"] = get_resource_dict("inflection-exceptions.csv", True)
     lookup_table["stop_words"] = get_resource_dict("mining-stopwords.csv", True)
+    lookup_table["resource_terms_ID_based"] = get_resource_dict("CombinedResourceTerms.csv")
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
         # Write lookup_table in JSON format
@@ -355,13 +356,10 @@ def run(args):
     samplesSet = []
     resource_terms = {}
     resource_terms_revised = {}
-    resource_terms_ID_based = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-    
-    # 21- To get all terms from resources- right now in a CSV file extracted from ontologies using another external script
-    resource_terms_ID_based = get_resource_dict("CombinedResourceTerms.csv")
+
     # Swap keys and values in resource_terms_ID_based
-    resource_terms = {v:k for k,v in resource_terms_ID_based.items()}
+    resource_terms = {v:k for k,v in lookup_table["resource_terms_ID_based"].items()}
     # Convert keys in resource_terms to lowercase
     resource_terms_revised = {k.lower():v for k,v in resource_terms.items()}
 
@@ -684,7 +682,7 @@ def run(args):
                 # Resource ID for matched_term's permutation
                 resource_id = resource_permutation_terms[matched_term]
                 # Permutation corresponding to matched_term
-                matched_permutation = resource_terms_ID_based[resource_id]
+                matched_permutation = lookup_table["resource_terms_ID_based"][resource_id]
                 # Update retained_tokens
                 retained_tokens.append(matched_permutation + ":"
                     + resource_id)
@@ -699,7 +697,7 @@ def run(args):
                 resource_id =\
                     resource_bracketed_permutation_terms[matched_term]
                 # Permutation corresponding to matched_term
-                matched_permutation = resource_terms_ID_based[resource_id]
+                matched_permutation = lookup_table["resource_terms_ID_based"][resource_id]
                 # Update retained_tokens
                 retained_tokens.append(matched_permutation + ":"
                     + resource_id)
@@ -735,7 +733,7 @@ def run(args):
                 # Resource ID for matched_term's permutation
                 resource_id = resource_permutation_terms[matched_term]
                 # Permutation corresponding to matched_term
-                matched_permutation = resource_terms_ID_based[resource_id]
+                matched_permutation = lookup_table["resource_terms_ID_based"][resource_id]
                 # Update retained_tokens
                 retained_tokens.append(matched_permutation + ":"
                     + resource_id)
@@ -751,7 +749,7 @@ def run(args):
                 resource_id =\
                     resource_bracketed_permutation_terms[matched_term]
                 # Permutation corresponding to matched_term
-                matched_permutation = resource_terms_ID_based[resource_id]
+                matched_permutation = lookup_table["resource_terms_ID_based"][resource_id]
                 # Update retained_tokens
                 retained_tokens.append(matched_permutation + ":"
                     + resource_id)
@@ -1263,11 +1261,11 @@ def run(args):
                     partialMatchedResourceList.append(matchstring + ":" + resourceId)
                 elif (matchstring in resource_permutation_terms.keys()):
                     resourceId = resource_permutation_terms[matchstring]
-                    resourceOriginalTerm = resource_terms_ID_based[resourceId]
+                    resourceOriginalTerm = lookup_table["resource_terms_ID_based"][resourceId]
                     partialMatchedResourceList.append(resourceOriginalTerm.lower() + ":" + resourceId)
                 elif (matchstring in resource_bracketed_permutation_terms.keys()):
                     resourceId = resource_bracketed_permutation_terms[matchstring]
-                    resourceOriginalTerm = resource_terms_ID_based[resourceId]
+                    resourceOriginalTerm = lookup_table["resource_terms_ID_based"][resourceId]
                     resourceOriginalTerm = resourceOriginalTerm.replace(",", "=")
                     partialMatchedResourceList.append(resourceOriginalTerm.lower() + ":" + resourceId)
                 elif (matchstring in lookup_table["processes"].keys()):

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -14,6 +14,7 @@ import sys
 from pkg_resources import resource_filename, resource_listdir
 import logging
 import collections
+import json
 
 logger = logging.getLogger("pipeline")
 logger.disabled = True
@@ -250,15 +251,36 @@ class MatchNotFoundError(Exception):
         """Return message when this class is raised as an exception."""
         return repr(self.message)
 
-def cache_resource_dict():
+def update_lookup_table():
     """...WIP
 
     TODO:
-        * should go through each resource dictionary, and check if they are cached
-            * if not, call get_resource_dict for each missing dictionary
+        * should compile and nest all resource dicts into one single dict
+        * load dict into lookup_table.json
         * implement function
         * write function docstring
     """
+    # set lookup_table to empty dictionary
+    # load each resource dictionary as seen in run, and add it to lookup_table
+    # save lookup_table as json file
+    return
+
+def load_lookup_table():
+    """...WIP
+e
+    TODO:
+        * should load global variable lookup_table from json file
+            * dict containing all resource dicts
+        * implement function
+        * write function docstring
+    """
+    # if lookup_table.json does not exist
+        # call update_lookup_table
+    # set lookup_table_modification_time to last modification time of lookup_table.json
+    # set resources_modification_time to last modification time of resources folder
+    # if resources_modification_time > lookup_modification_time
+        # call update_lookup_table
+    # load lookup_table.json as dict into global variable lookup_table
     return
 
 def run(args):

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -283,14 +283,14 @@ def load_lookup_table():
     TODO:
         * write function docstring
         * follow single responsibility principle more closely
+        * figure out why you need get_path in some cases, but not
+            others
     """
     # lookup_table.json exists
     if os.path.isfile("lookup_table.json"):
         # last modification time of lookup_table.json
-        lookup_table_modification_time = os.path.getmtime(get_path("lookup_table.json"))
+        lookup_table_modification_time = os.path.getmtime("lookup_table.json")
 
-        # Path to resources folder
-        resources_path = os.path.join(os.path.dirname(__file__), "resources")
         # list of all file names in resources folder
         resource_names = [file_name for file_name in os.listdir(get_path("resources"))]
         # list of paths to all files in resources folder

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -347,7 +347,7 @@ def is_lookup_table_outdated():
         * should only be called if lookup_table.json exists
     """
     # last modification time of lookup_table.json
-    lookup_table_modification_time = os.path.getmtime("lookup_table.json")
+    lookup_table_modification_time = os.path.getmtime(get_path("lookup_table.json"))
 
     # list of all file names in resources folder
     resource_names = [file_name for file_name in os.listdir(get_path("resources"))]
@@ -374,7 +374,7 @@ def add_lookup_table_to_cache():
     # Will contain all resource dictionaries
     lookup_table = get_all_resource_dicts()
     # Open and write to lookup_table.json
-    with open("lookup_table.json", "w") as file:
+    with open(get_path("lookup_table.json"), "w") as file:
         # Write lookup_table in JSON format
         json.dump(lookup_table, file)
     return
@@ -389,7 +389,7 @@ def get_lookup_table_from_cache():
             others
     """
     # lookup_table.json exists
-    if os.path.isfile("lookup_table.json"):
+    if os.path.isfile(get_path("lookup_table.json")):
         # lookup_table.json out of date
         if is_lookup_table_outdated():
             # add new lookup table to cache
@@ -399,7 +399,7 @@ def get_lookup_table_from_cache():
         # add lookup table to cache
         add_lookup_table_to_cache()
     # Open and read lookup_table.json
-    with open("lookup_table.json", "r") as file:
+    with open(get_path("lookup_table.json"), "r") as file:
         # Return lookup_table contents
         return json.load(file)
 

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -234,7 +234,7 @@ def get_all_resource_dicts():
 
     Return values:
         * class <"dict">: Contains key-value pairs corresponding to
-            files in 'resources/'
+            files in "resources/"
             * key: class <"str">
             * val: class <"dict">
     """
@@ -387,24 +387,32 @@ def add_lookup_table_to_cache():
     """Saves nested dictionary of resources to a local file.
 
     The nested dictionary corresponds to the return value of
-    get_all_resource_dicts, and is saved as lookup_table.json.
+    get_all_resource_dicts, and is saved as lookup_table.json. If such
+    a file already exists, it will be overwritten.
     """
-    # Will contain all resource dictionaries
+    # Nested dictionary of all resource dictionaries used in run
     lookup_table = get_all_resource_dicts()
     # Open and write to lookup_table.json
     with open(get_path("lookup_table.json"), "w") as file:
         # Write lookup_table in JSON format
         json.dump(lookup_table, file)
-    return
 
 def get_lookup_table_from_cache():
-    """...WIP
+    """Return contents of lookup_table.json.
 
-    TODO:
-        * write function docstring
-        * follow single responsibility principle more closely
-        * figure out why you need get_path in some cases, but not
-            others
+    The contents of lookup_table.json correspond to the return value of
+    get_all_resource_dicts. Retrieving said contents from
+    lookup_table.json is faster than running get_all_resource_dicts.
+
+    If lookup_table.json does not exist, or is outdated (see
+    is_lookup_table_outdated for details), a new lookup_table.json file
+    is generated.
+
+    Return values:
+        * class <"dict">: Contains key-value pairs corresponding to
+            files in "resources/"
+            * key: class <"str">
+            * val: class <"dict">
     """
     # lookup_table.json exists
     if os.path.isfile(get_path("lookup_table.json")):

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -278,6 +278,8 @@ def update_lookup_table():
     lookup_table["spelling_mistakes"] = get_resource_dict("ScorLex.csv")
     lookup_table["spelling_mistakes_lower"] = get_resource_dict("ScorLex.csv", True)
     lookup_table["processes"] = get_resource_dict("candidateProcesses.csv")
+    lookup_table["qualities"] = get_resource_dict("SemLex.csv")
+    lookup_table["qualities_lower"] = get_resource_dict("SemLex.csv", True)
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
         # Write lookup_table in JSON format
@@ -352,10 +354,6 @@ def run(args):
     resource_terms_revised = {}
     resource_terms_ID_based = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-    
-    # 16-Get all semantic tags (e.g.qualities) from resource in a CSV file format and put in a dictionary to be used further
-    qualities = get_resource_dict("SemLex.csv")
-    qualities_lower = get_resource_dict("SemLex.csv", True)
 
     # 17-Get all collocations (Wikipedia) from resource in a CSV file format and put in a dictionary to be used further
     collocations = get_resource_dict("wikipediaCollocations.csv")
@@ -1077,8 +1075,8 @@ def run(args):
                             localTrigger = True
 
                     # Here the qualities are used for semantic taggings --- change elif to if for qualities in addition to
-                    if (grm in qualities_lower.keys() and not localTrigger):
-                        quality = qualities_lower[grm]
+                    if (grm in lookup_table["qualities_lower"].keys() and not localTrigger):
+                        quality = lookup_table["qualities_lower"][grm]
                         partialMatchedList.append(grm)
                         status_addendum.append("Using Semantic Tagging Resources")
                         localTrigger = True
@@ -1148,8 +1146,8 @@ def run(args):
                         localTrigger = True
 
                     # Here the qualities are used for semantic taggings --- change elif to if for qualities in addition to
-                    if (grm in qualities_lower.keys() and not localTrigger):
-                        quality = qualities_lower[grm]
+                    if (grm in lookup_table["qualities_lower"].keys() and not localTrigger):
+                        quality = lookup_table["qualities_lower"][grm]
                         partialMatchedList.append(grm)
                         status_addendum.append("Using Semantic Tagging Resources")
                         localTrigger = True
@@ -1210,8 +1208,8 @@ def run(args):
                         localTrigger=True
 
                 # Here the qualities are used for semantic taggings --- change elif to if for qualities in addition to
-                if (grm in qualities_lower.keys() and not localTrigger):
-                    quality = qualities_lower[grm]
+                if (grm in lookup_table["qualities_lower"].keys() and not localTrigger):
+                    quality = lookup_table["qualities_lower"][grm]
                     partialMatchedList.append(grm)
                     status_addendum.append("Using Semantic Tagging Resources")
                     localTrigger = True
@@ -1282,11 +1280,11 @@ def run(args):
                 elif (matchstring in lookup_table["processes"].keys()):
                     resourceId = lookup_table["processes"][matchstring]
                     partialMatchedResourceList.append(matchstring + ":" + resourceId)
-                elif (matchstring in qualities.keys()):
-                    resourceId = qualities[matchstring]
+                elif (matchstring in lookup_table["qualities"].keys()):
+                    resourceId = lookup_table["qualities"][matchstring]
                     partialMatchedResourceList.append(matchstring + ":" + resourceId)
-                elif (matchstring in qualities_lower.keys()):
-                    resourceId = qualities_lower[matchstring]
+                elif (matchstring in lookup_table["qualities_lower"].keys()):
+                    resourceId = lookup_table["qualities_lower"][matchstring]
                     partialMatchedResourceList.append(matchstring + ":" + resourceId)
                 elif ("==" in matchstring):
                     resList = matchstring.split("==")

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -285,7 +285,7 @@ def load_lookup_table():
         * follow single responsibility principle more closely
     """
     # lookup_table.json exists
-    if os.path.isfile(get_path("lookup_table.json")):
+    if os.path.isfile("lookup_table.json"):
         # last modification time of lookup_table.json
         lookup_table_modification_time = os.path.getmtime(get_path("lookup_table.json"))
 
@@ -312,7 +312,7 @@ def load_lookup_table():
     # Allow modifications to global variable lookup_table
     global lookup_table
     # Open and read lookup_table.json
-    with open(get_path("lookup_table.json"), "r") as file:
+    with open("lookup_table.json", "r") as file:
         # Write contents to lookup_table
         lookup_table = json.load(file)
     return

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -263,7 +263,7 @@ def update_lookup_table():
         * implement function
         * write function docstring
     """
-    # Will contain all resource dictionaries locally
+    # Will contain all resource dictionaries
     lookup_table = {}
     # TODO: load each resource dictionary as seen in run, and add it to
     #       lookup_table.
@@ -289,7 +289,7 @@ def load_lookup_table():
     # set resources_modification_time to last modification time of resources folder
     # if resources_modification_time > lookup_modification_time
         # call update_lookup_table
-    # Allow global modifications to lookup_table
+    # Allow modifications to global variable lookup_table
     global lookup_table
     # Open and read lookup_table.json
     with open("lookup_table.json", "r") as file:
@@ -304,8 +304,8 @@ def run(args):
     # TODO: remove this later
     update_lookup_table()
     load_lookup_table()
-    print(lookup_table)
-    sys.exit()
+    # print(lookup_table)
+    # sys.exit()
     punctuations = ['-', '_', '(', ')', ';', '/', ':', '%']  # Current punctuations for basic treatment
     covered_tokens = []
     remainingAllTokensSet = []
@@ -318,9 +318,6 @@ def run(args):
     resource_terms_revised = {}
     resource_terms_ID_based = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-
-    # 11-Get all synonyms from resource in CSV file format and put in a dictionary to be used further
-    synonyms = get_resource_dict("SynLex.csv")
 
     # 12-Get all abbreviation/acronyms from resource in CSV file format and put in a dictionary to be used further
     abbreviations = get_resource_dict("AbbLex.csv")
@@ -898,8 +895,8 @@ def run(args):
                     if (grm in non_english_words.keys()):  # rule for abbreviation
                         grm = non_english_words[grm]
                         status_addendum.append("Non English Language Words Treatment")
-                    if (grm in synonyms.keys()):  ## Synonyms taken care of- need more synonyms
-                        grm = synonyms[grm]
+                    if (grm in lookup_table["synonyms"].keys()):  ## Synonyms taken care of- need more synonyms
+                        grm = lookup_table["synonyms"][grm]
                         status_addendum.append("Synonym Usage")
 
                     # Matching Test for 5-gram chunk
@@ -958,8 +955,8 @@ def run(args):
                     if (grm in non_english_words.keys()):  # rule for abbreviation
                         grm = non_english_words[grm]
                         status_addendum.append("Non English Language Words Treatment")
-                    if (grm in synonyms.keys()):  ## Synonyms taken care of- need more synonyms
-                        grm = synonyms[grm]
+                    if (grm in lookup_table["synonyms"].keys()):  ## Synonyms taken care of- need more synonyms
+                        grm = lookup_table["synonyms"][grm]
                         status_addendum.append("Synonym Usage")
 
                     # Matching Test for 4-gram chunk
@@ -1019,8 +1016,8 @@ def run(args):
                     if (grm in non_english_words.keys()):  # rule for abbreviation
                         grm = non_english_words[grm]
                         status_addendum.append("Non English Language Words Treatment")
-                    if (grm in synonyms.keys()):  ## Synonyms taken care of- need more synonyms
-                        grm = synonyms[grm]
+                    if (grm in lookup_table["synonyms"].keys()):  ## Synonyms taken care of- need more synonyms
+                        grm = lookup_table["synonyms"][grm]
                         status_addendum.append("Synonym Usage")
 
                     # Matching Test for 3-gram chunk
@@ -1090,8 +1087,8 @@ def run(args):
                     if (grm in non_english_words.keys()):  # rule for abbreviation
                         grm = non_english_words[grm]
                         status_addendum.append("Non English Language Words Treatment")
-                    if (grm in synonyms.keys()):  ## Synonyms taken care of- need more synonyms
-                        grm = synonyms[grm]
+                    if (grm in lookup_table["synonyms"].keys()):  ## Synonyms taken care of- need more synonyms
+                        grm = lookup_table["synonyms"][grm]
                         status_addendum.append("Synonym Usage")
 
                     # Matching Test for 2-gram chunk
@@ -1160,8 +1157,8 @@ def run(args):
                 if (grm in non_english_words.keys()):  # rule for abbreviation
                     grm = non_english_words[grm]
                     status_addendum.append("Non English Language Words Treatment")
-                if (grm in synonyms.keys()):  ## Synonyms taken care of- need more synonyms
-                    grm = synonyms[grm]
+                if (grm in lookup_table["synonyms"].keys()):  ## Synonyms taken care of- need more synonyms
+                    grm = lookup_table["synonyms"][grm]
                     status_addendum.append("Synonym Usage")
 
                 # Matching Test for 1-gram chunk

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -16,6 +16,9 @@ import logging
 import collections
 import json
 
+# Will contain all resource dictionaries
+lookup_table = {}
+
 logger = logging.getLogger("pipeline")
 logger.disabled = True
 
@@ -260,11 +263,14 @@ def update_lookup_table():
         * implement function
         * write function docstring
     """
-    # Dictionary that will contain all resource dictionaries
+    # Will contain all resource dictionaries locally
     lookup_table = {}
-    # load each resource dictionary as seen in run, and add it to lookup_table
+    # TODO: load each resource dictionary as seen in run, and add it to
+    #       lookup_table.
+    lookup_table["synonyms"] = get_resource_dict("SynLex.csv")
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
+        # Write lookup_table in JSON format
         json.dump(lookup_table, file)
     return
 
@@ -283,7 +289,12 @@ def load_lookup_table():
     # set resources_modification_time to last modification time of resources folder
     # if resources_modification_time > lookup_modification_time
         # call update_lookup_table
-    # load lookup_table.json as dict into global variable lookup_table
+    # Allow global modifications to lookup_table
+    global lookup_table
+    # Open and read lookup_table.json
+    with open("lookup_table.json", "r") as file:
+        # Write contents to lookup_table
+        lookup_table = json.load(file)
     return
 
 def run(args):
@@ -292,6 +303,8 @@ def run(args):
     """
     # TODO: remove this later
     update_lookup_table()
+    load_lookup_table()
+    print(lookup_table)
     sys.exit()
     punctuations = ['-', '_', '(', ')', ';', '/', ':', '%']  # Current punctuations for basic treatment
     covered_tokens = []

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -286,6 +286,8 @@ def update_lookup_table():
     lookup_table["resource_terms_ID_based"] = get_resource_dict("CombinedResourceTerms.csv")
     # TODO: reduce line length
     lookup_table["resource_terms"] = {v:k for k,v in lookup_table["resource_terms_ID_based"].items()}
+    # TODO: reduce line length
+    lookup_table["resource_terms_revised"] = {k.lower():v for k,v in lookup_table["resource_terms"].items()}
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
         # Write lookup_table in JSON format
@@ -356,16 +358,12 @@ def run(args):
     samplesDict = collections.OrderedDict()
     samplesList = []
     samplesSet = []
-    resource_terms_revised = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-
-    # Convert keys in resource_terms to lowercase
-    resource_terms_revised = {k.lower():v for k,v in lookup_table["resource_terms"].items()}
 
     # 23-Method for getting all the permutations of Resource Terms
     resource_permutation_terms = {}
     # Iterate
-    for k, v in resource_terms_revised.items():
+    for k, v in lookup_table["resource_terms_revised"].items():
         resourceid = v
         resource = k
         if "(" not in resource:
@@ -384,7 +382,7 @@ def run(args):
     # 24-Method for getting all the permutations of Bracketed Resource Terms
     resource_bracketed_permutation_terms={}
     # Iterate
-    for k, v in resource_terms_revised.items():
+    for k, v in lookup_table["resource_terms_revised"].items():
         resourceid = v
         resource1 = k
         sampleTokens = word_tokenize(resource1.lower())
@@ -665,11 +663,11 @@ def run(args):
                 # Update status_addendum
                 status_addendum.append("Change of Case in Input Data")
             # Full-term match with change-of-case in resource data
-            elif sample.lower() in resource_terms_revised:
+            elif sample.lower() in lookup_table["resource_terms_revised"]:
                 # Term with we found a full-term match for
                 matched_term = sample.lower()
                 # Resource ID for matched_term
-                resource_id = resource_terms_revised[matched_term]
+                resource_id = lookup_table["resource_terms_revised"][matched_term]
                 # Update retained_tokens
                 retained_tokens.append(matched_term + ":" + resource_id)
                 # Update status_addendum
@@ -715,11 +713,11 @@ def run(args):
                 status_addendum.append("A Direct Match with Cleaned Sample")
             # Full-term cleaned sample match with change-of-case in
             # resource data.
-            elif cleaned_sample.lower() in resource_terms_revised:
+            elif cleaned_sample.lower() in lookup_table["resource_terms_revised"]:
                 # Term with we found a full-term match for
                 matched_term = cleaned_sample.lower()
                 # Resource ID for matched_term
-                resource_id = resource_terms_revised[matched_term]
+                resource_id = lookup_table["resource_terms_revised"][matched_term]
                 # Update retained_tokens
                 retained_tokens.append(matched_term + ":" + resource_id)
                 # Update status_addendum
@@ -776,12 +774,12 @@ def run(args):
                 # in resource_terms_revised.
                 matched_suffixes =\
                     [s for s in suffixes
-                        if sample+" "+s in resource_terms_revised]
+                        if sample+" "+s in lookup_table["resource_terms_revised"]]
                 # Find all suffixes that when appended to cleaned
                 # sample, are in resource_terms_revised.
                 matched_clean_suffixes =\
                     [s for s in suffixes
-                        if cleaned_sample+" "+s in resource_terms_revised]
+                        if cleaned_sample+" "+s in lookup_table["resource_terms_revised"]]
                 # A full-term match with change of resource and suffix
                 # addition exists.
                 if matched_suffixes:
@@ -791,7 +789,7 @@ def run(args):
                     # Term we add a suffix to
                     matched_term = sample.lower()
                     # Resource ID for matched_term
-                    resource_id = resource_terms_revised[term_with_suffix]
+                    resource_id = lookup_table["resource_terms_revised"][term_with_suffix]
                     # Update retained_tokens
                     retained_tokens.append(term_with_suffix + ":"
                         + resource_id)
@@ -810,7 +808,7 @@ def run(args):
                     # Term we cleaned and added a suffix to
                     matched_term = sample.lower()
                     # Resource ID for matched_term
-                    resource_id = resource_terms_revised[term_with_suffix]
+                    resource_id = lookup_table["resource_terms_revised"][term_with_suffix]
                     # Update retained_tokens
                     retained_tokens.append(term_with_suffix + ":"
                         + resource_id)
@@ -914,7 +912,7 @@ def run(args):
                             if eachTkn in remaining_tokens:
                                 remaining_tokens.remove(eachTkn)
                         localTrigger = True
-                    elif ((grm in resource_terms_revised.keys() )and not localTrigger):
+                    elif ((grm in lookup_table["resource_terms_revised"].keys() )and not localTrigger):
                         partialMatchedList.append(grm)
                         for eachTkn in grmTokens:
                             covered_tokens.append(eachTkn)
@@ -933,7 +931,7 @@ def run(args):
                     for suff in range(len(suffixes)):
                         suffixString = suffixes[suff]
                         sampleRevisedWithSuffix = grm + " " + suffixString
-                        if (sampleRevisedWithSuffix in resource_terms_revised.keys() and not localTrigger):  # Not trigger true is used here -reason
+                        if (sampleRevisedWithSuffix in lookup_table["resource_terms_revised"].keys() and not localTrigger):  # Not trigger true is used here -reason
                             # resourceId = resourceRevisedTermsDict[sampleRevisedWithSuffix]
                             partialMatchedList.append(sampleRevisedWithSuffix)
                             status_addendum.append("Suffix Addition- " + suffixString + " to the Input")
@@ -974,7 +972,7 @@ def run(args):
                             if eachTkn in remaining_tokens:
                                 remaining_tokens.remove(eachTkn)
                         localTrigger = True
-                    elif ((  grm in resource_terms_revised.keys() ) and not localTrigger):
+                    elif ((  grm in lookup_table["resource_terms_revised"].keys() ) and not localTrigger):
                         partialMatchedList.append(grm)
                         for eachTkn in grmTokens:
                             covered_tokens.append(eachTkn)
@@ -993,7 +991,7 @@ def run(args):
                     for suff in range(len(suffixes)):
                         suffixString = suffixes[suff]
                         sampleRevisedWithSuffix = grm + " " + suffixString
-                    if (sampleRevisedWithSuffix in resource_terms_revised.keys() and not localTrigger):  # Not trigger true is used here -reason
+                    if (sampleRevisedWithSuffix in lookup_table["resource_terms_revised"].keys() and not localTrigger):  # Not trigger true is used here -reason
                         # resourceId = resourceRevisedTermsDict[sampleRevisedWithSuffix]
                         partialMatchedList.append(sampleRevisedWithSuffix)
                         status_addendum.append("Suffix Addition- " + suffixString + " to the Input")
@@ -1035,7 +1033,7 @@ def run(args):
                             if eachTkn in remaining_tokens:
                                 remaining_tokens.remove(eachTkn)
                         localTrigger = True
-                    elif ((grm in resource_terms_revised.keys() ) and not localTrigger):
+                    elif ((grm in lookup_table["resource_terms_revised"].keys() ) and not localTrigger):
                         partialMatchedList.append(grm)
                         for eachTkn in grmTokens:
                             covered_tokens.append(eachTkn)
@@ -1054,7 +1052,7 @@ def run(args):
                     for suff in range(len(suffixes)):
                         suffixString = suffixes[suff]
                         sampleRevisedWithSuffix = grm + " " + suffixString
-                        if (sampleRevisedWithSuffix in resource_terms_revised.keys() and not localTrigger):  # Not trigger true is used here -reason
+                        if (sampleRevisedWithSuffix in lookup_table["resource_terms_revised"].keys() and not localTrigger):  # Not trigger true is used here -reason
                             # resourceId = resourceRevisedTermsDict[sampleRevisedWithSuffix]
                             partialMatchedList.append(sampleRevisedWithSuffix)
                             status_addendum.append("Suffix Addition- " + suffixString + " to the Input")
@@ -1106,7 +1104,7 @@ def run(args):
                             if eachTkn in remaining_tokens:
                                 remaining_tokens.remove(eachTkn)
                         localTrigger = True
-                    elif (( grm in resource_terms_revised.keys() ) and not localTrigger):
+                    elif (( grm in lookup_table["resource_terms_revised"].keys() ) and not localTrigger):
                         partialMatchedList.append(grm)
                         for eachTkn in grmTokens:
                             covered_tokens.append(eachTkn)
@@ -1125,7 +1123,7 @@ def run(args):
                     for suff in range(len(suffixes)):
                         suffixString = suffixes[suff]
                         sampleRevisedWithSuffix = grm + " " + suffixString
-                    if (sampleRevisedWithSuffix in resource_terms_revised.keys() and not localTrigger):  # Not trigger true is used here -reason
+                    if (sampleRevisedWithSuffix in lookup_table["resource_terms_revised"].keys() and not localTrigger):  # Not trigger true is used here -reason
                         # resourceId = resourceRevisedTermsDict[sampleRevisedWithSuffix]
                         partialMatchedList.append(sampleRevisedWithSuffix)
                         status_addendum.append("Suffix Addition- " + suffixString + " to the Input")
@@ -1176,7 +1174,7 @@ def run(args):
                         if eachTkn in remaining_tokens:
                             remaining_tokens.remove(eachTkn)
                     localTrigger = True
-                elif ((grm in resource_terms_revised.keys() ) and not localTrigger):
+                elif ((grm in lookup_table["resource_terms_revised"].keys() ) and not localTrigger):
                     partialMatchedList.append(grm)
                     for eachTkn in grmTokens:
                         covered_tokens.append(eachTkn)
@@ -1187,7 +1185,7 @@ def run(args):
                 for suff in range(len(suffixes)):
                     suffixString = suffixes[suff]
                     sampleRevisedWithSuffix = grm + " " + suffixString
-                    if (sampleRevisedWithSuffix in resource_terms_revised.keys() and not localTrigger):  # Not trigger true is used here -reason
+                    if (sampleRevisedWithSuffix in lookup_table["resource_terms_revised"].keys() and not localTrigger):  # Not trigger true is used here -reason
                         # resourceId = resourceRevisedTermsDict[sampleRevisedWithSuffix]
                         partialMatchedList.append(sampleRevisedWithSuffix)
                         status_addendum.append("Suffix Addition- " + suffixString + " to the Input")
@@ -1255,8 +1253,8 @@ def run(args):
                 if (matchstring in lookup_table["resource_terms"].keys()):
                     resourceId = lookup_table["resource_terms"][matchstring]
                     partialMatchedResourceList.append(matchstring + ":" + resourceId)
-                elif (matchstring in resource_terms_revised.keys()):
-                    resourceId = resource_terms_revised[matchstring]
+                elif (matchstring in lookup_table["resource_terms_revised"].keys()):
+                    resourceId = lookup_table["resource_terms_revised"][matchstring]
                     partialMatchedResourceList.append(matchstring + ":" + resourceId)
                 elif (matchstring in resource_permutation_terms.keys()):
                     resourceId = resource_permutation_terms[matchstring]

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -277,6 +277,7 @@ def update_lookup_table():
     lookup_table["non_english_words_lower"] = get_resource_dict("NefLex.csv", True)
     lookup_table["spelling_mistakes"] = get_resource_dict("ScorLex.csv")
     lookup_table["spelling_mistakes_lower"] = get_resource_dict("ScorLex.csv", True)
+    lookup_table["processes"] = get_resource_dict("candidateProcesses.csv")
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
         # Write lookup_table in JSON format
@@ -351,9 +352,6 @@ def run(args):
     resource_terms_revised = {}
     resource_terms_ID_based = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-
-    # 15-Get candidate processes from resource in a CSV file format and put in a dictionary to be used further
-    processes = get_resource_dict("candidateProcesses.csv")
     
     # 16-Get all semantic tags (e.g.qualities) from resource in a CSV file format and put in a dictionary to be used further
     qualities = get_resource_dict("SemLex.csv")
@@ -1224,8 +1222,8 @@ def run(args):
 
 
                 # Here the qualities are used for semantic taggings --- change elif to if for qualities in addition to
-                if (grm in processes.keys() and not localTrigger):
-                    proc = processes[grm]
+                if (grm in lookup_table["processes"].keys() and not localTrigger):
+                    proc = lookup_table["processes"][grm]
                     partialMatchedList.append(grm)
                     status_addendum.append("Using Candidate Processes")
                     localTrigger = True
@@ -1281,8 +1279,8 @@ def run(args):
                     resourceOriginalTerm = resource_terms_ID_based[resourceId]
                     resourceOriginalTerm = resourceOriginalTerm.replace(",", "=")
                     partialMatchedResourceList.append(resourceOriginalTerm.lower() + ":" + resourceId)
-                elif (matchstring in processes.keys()):
-                    resourceId = processes[matchstring]
+                elif (matchstring in lookup_table["processes"].keys()):
+                    resourceId = lookup_table["processes"][matchstring]
                     partialMatchedResourceList.append(matchstring + ":" + resourceId)
                 elif (matchstring in qualities.keys()):
                     resourceId = qualities[matchstring]

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -260,14 +260,17 @@ def update_lookup_table():
         * implement function
         * write function docstring
     """
-    # set lookup_table to empty dictionary
+    # Dictionary that will contain all resource dictionaries
+    lookup_table = {}
     # load each resource dictionary as seen in run, and add it to lookup_table
-    # save lookup_table as json file
+    # Open and write to lookup_table.json
+    with open("lookup_table.json", "w") as file:
+        json.dump(lookup_table, file)
     return
 
 def load_lookup_table():
     """...WIP
-e
+
     TODO:
         * should load global variable lookup_table from json file
             * dict containing all resource dicts
@@ -287,6 +290,9 @@ def run(args):
     """
     Main text mining pipeline.
     """
+    # TODO: remove this later
+    update_lookup_table()
+    sys.exit()
     punctuationsList = ['-', '_', '(', ')', ';', '/', ':', '%']  # Current punctuationsList for basic treatment
     covered_tokens = []
     remainingAllTokensSet = []

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -282,6 +282,7 @@ def update_lookup_table():
     lookup_table["qualities_lower"] = get_resource_dict("SemLex.csv", True)
     lookup_table["collocations"] = get_resource_dict("wikipediaCollocations.csv")
     lookup_table["inflection_exceptions"] = get_resource_dict("inflection-exceptions.csv", True)
+    lookup_table["stop_words"] = get_resource_dict("mining-stopwords.csv", True)
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
         # Write lookup_table in JSON format
@@ -356,10 +357,6 @@ def run(args):
     resource_terms_revised = {}
     resource_terms_ID_based = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-    
-    # 19-Method to Get all stop words from resource in CSV file format -A very constrained lists of stop words is
-    # used as other stop words are assumed to have some useful semantic meaning
-    stop_words = get_resource_dict("mining-stopwords.csv", True)
     
     # 21- To get all terms from resources- right now in a CSV file extracted from ontologies using another external script
     resource_terms_ID_based = get_resource_dict("CombinedResourceTerms.csv")
@@ -521,10 +518,10 @@ def run(args):
 
 
             # ===This will create a cleaned sample after above treatments [Here we are making new phrase now in lower case]
-            if (not cleaned_sample and lemma.lower() not in stop_words):  # if newphrase is empty and lemma is in not in stopwordlist (abridged according to domain)
+            if (not cleaned_sample and lemma.lower() not in lookup_table["stop_words"]):  # if newphrase is empty and lemma is in not in stopwordlist (abridged according to domain)
                 cleaned_sample = lemma.lower()
             elif (
-                lemma.lower() not in stop_words):  # if newphrase is not empty and lemma is in not in stopwordlist (abridged according to domain)
+                lemma.lower() not in lookup_table["stop_words"]):  # if newphrase is not empty and lemma is in not in stopwordlist (abridged according to domain)
                 cleaned_sample = cleaned_sample + " " + lemma.lower()
 
             cleaned_sample = re.sub(' +', ' ', cleaned_sample)  # Extra innner spaces removed from cleaned sample

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -15,6 +15,7 @@ from pkg_resources import resource_filename, resource_listdir
 import logging
 import collections
 import json
+from os import path
 
 # Will contain all resource dictionaries
 lookup_table = {}
@@ -283,8 +284,10 @@ def load_lookup_table():
         * implement function
         * write function docstring
     """
-    # if lookup_table.json does not exist
-        # call update_lookup_table
+    # lookup_table.json does not exist
+    if not path.isfile("lookup_table.json"):
+        # update lookup_table
+        update_lookup_table()
     # set lookup_table_modification_time to last modification time of lookup_table.json
     # set resources_modification_time to last modification time of resources folder
     # if resources_modification_time > lookup_modification_time
@@ -302,10 +305,10 @@ def run(args):
     Main text mining pipeline.
     """
     # TODO: remove this later
-    update_lookup_table()
+    # update_lookup_table()
     load_lookup_table()
     # print(lookup_table)
-    # sys.exit()
+    sys.exit()
     punctuations = ['-', '_', '(', ')', ';', '/', ':', '%']  # Current punctuations for basic treatment
     covered_tokens = []
     remainingAllTokensSet = []

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -293,7 +293,7 @@ def run(args):
     # TODO: remove this later
     update_lookup_table()
     sys.exit()
-    punctuationsList = ['-', '_', '(', ')', ';', '/', ':', '%']  # Current punctuationsList for basic treatment
+    punctuations = ['-', '_', '(', ')', ';', '/', ':', '%']  # Current punctuations for basic treatment
     covered_tokens = []
     remainingAllTokensSet = []
     remainingTokenSet = []
@@ -449,7 +449,7 @@ def run(args):
         #   sample_desc: sample
         fw.write('\n' + sampleid + '\t' + sample)
 
-        sample = punctuationTreatment(sample, punctuationsList)  # Sample gets simple punctuation treatment
+        sample = punctuationTreatment(sample, punctuations)  # Sample gets simple punctuation treatment
         sample = re.sub(' +', ' ', sample)  # Extra innner spaces are removed
         sampleTokens = word_tokenize(sample.lower())    #Sample is tokenized into tokenList
 

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -272,7 +272,6 @@ def update_lookup_table():
     #       lookup_table.
     lookup_table["synonyms"] = get_resource_dict("SynLex.csv")
     lookup_table["abbreviations"] = get_resource_dict("AbbLex.csv")
-    # TODO: this is not used
     lookup_table["abbreviation_lower"] = get_resource_dict("AbbLex.csv", True)
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
@@ -302,7 +301,6 @@ def load_lookup_table():
         resources_files_modification_times = [os.path.getmtime(path) for path in resource_paths]
         # most recent modification time of a file in resources folder
         resources_folder_modification_time = max(resources_files_modification_times)
-        print(resources_folder_modification_time)
 
         # resources modified more recently than lookup_table.json
         if resources_folder_modification_time > lookup_table_modification_time:
@@ -522,8 +520,8 @@ def run(args):
             if (lemma in lookup_table["abbreviations"].keys()):  # Abbreviations, acronyms, foreign language words taken care of- need rule for abbreviation e.g. if lemma is Abbreviation
                 lemma = lookup_table["abbreviations"][lemma]
                 status_addendum.append("Abbreviation-Acronym Treatment")
-            elif (lemma.lower() in abbreviation_lower.keys()):
-                lemma = abbreviation_lower[lemma.lower()]
+            elif (lemma.lower() in lookup_table["abbreviation_lower"].keys()):
+                lemma = lookup_table["abbreviation_lower"][lemma.lower()]
                 status_addendum.append("Change Case and Abbreviation-Acronym Treatment")
 
             if (lemma in non_english_words.keys()):  # Non English language words taken care of
@@ -546,8 +544,8 @@ def run(args):
             if (cleaned_sample in lookup_table["abbreviations"].keys()):  # NEED HERE AGAIN ? Abbreviations, acronyms, non English words taken care of- need rule for abbreviation
                 cleaned_sample = lookup_table["abbreviations"][cleaned_sample]
                 status_addendum.append("Cleaned Sample and Abbreviation-Acronym Treatment")
-            elif (cleaned_sample in abbreviation_lower.keys()):
-                cleaned_sample = abbreviation_lower[cleaned_sample]
+            elif (cleaned_sample in lookup_table["abbreviation_lower"].keys()):
+                cleaned_sample = lookup_table["abbreviation_lower"][cleaned_sample]
                 status_addendum.append("Cleaned Sample and Abbreviation-Acronym Treatment")
 
             if (cleaned_sample in non_english_words.keys()):  # non English words taken care of

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -329,7 +329,7 @@ class MatchNotFoundError(Exception):
         """Return message when this class is raised as an exception."""
         return repr(self.message)
 
-def update_lookup_table():
+def add_lookup_table_to_cache():
     """...WIP
 
     TODO:
@@ -357,11 +357,11 @@ def load_lookup_table():
     if os.path.isfile("lookup_table.json"):
         # lookup_table.json out of date
         if is_lookup_table_outdated():
-            update_lookup_table()
+            add_lookup_table_to_cache()
     # lookup_table.json does not exist
     else:
         # update lookup_table
-        update_lookup_table()
+        add_lookup_table_to_cache()
     # Allow modifications to global variable lookup_table
     global lookup_table
     # Open and read lookup_table.json

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -281,18 +281,30 @@ def load_lookup_table():
     TODO:
         * write function docstring
     """
-    # Path to resources folder
-    resources_path = os.path.join(os.path.dirname(__file__), "resources")
     # lookup_table.json exists
     if os.path.isfile("lookup_table.json"):
         # last modification time of lookup_table.json
         lookup_table_modification_time = os.path.getmtime("lookup_table.json")
-        # list of all files in resources folder
-        resource_files = ["resources/"+file_name for file_name in os.listdir(resources_path)]
-        # list of all modification times for files in resource_files
-        resource_files_modification_times = [os.path.getmtime(file) for file in resource_files]
+
+        # Path to resources folder
+        resources_path = os.path.join(os.path.dirname(__file__), "resources")
+        # list of all file names in resources folder
+        resource_file_names = [file_name for file_name in os.listdir(resources_path)]
+        # list of paths to files in resources folder
+        resource_file_paths = [
+            os.path.join(
+                os.path.dirname(__file__),
+                "resources/" + file_name)
+            for file_name
+            in resource_file_names]
+        # list of all modification times for files in resource_file_paths
+        resource_files_modification_times = [
+            os.path.getmtime(file_path)
+            for file_path
+            in resource_file_paths]
         # most recent modification time of a file in resources folder
         resources_folder_modification_time = max(resource_files_modification_times)
+
         # resources modified more recently than lookup_table.json
         if resources_folder_modification_time > lookup_table_modification_time:
             # update lookup_table

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -279,9 +279,6 @@ def load_lookup_table():
     """...WIP
 
     TODO:
-        * should load global variable lookup_table from json file
-            * dict containing all resource dicts
-        * implement function
         * write function docstring
     """
     # lookup_table.json exists
@@ -317,8 +314,8 @@ def run(args):
     # TODO: remove this later
     # update_lookup_table()
     load_lookup_table()
-    # print(lookup_table)
-    sys.exit()
+    # # print(lookup_table)
+    # sys.exit()
     punctuations = ['-', '_', '(', ')', ';', '/', ':', '%']  # Current punctuations for basic treatment
     covered_tokens = []
     remainingAllTokensSet = []

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -326,6 +326,34 @@ class MatchNotFoundError(Exception):
         """Return message when this class is raised as an exception."""
         return repr(self.message)
 
+def get_path(file_name, prefix=""):
+    """...WIP
+
+    TODO:
+        * write function docstring
+    """
+    return os.path.join(os.path.dirname(__file__), prefix+file_name)
+
+def is_lookup_table_outdated():
+    """...WIP"""
+    # last modification time of lookup_table.json
+    lookup_table_modification_time = os.path.getmtime("lookup_table.json")
+
+    # list of all file names in resources folder
+    resource_names = [file_name for file_name in os.listdir(get_path("resources"))]
+    # list of paths to all files in resources folder
+    resource_paths = [get_path(file_name, "resources/") for file_name in resource_names]
+    # list of last modification times for files in resources folder
+    resources_files_modification_times = [os.path.getmtime(path) for path in resource_paths]
+    # most recent modification time of a file in resources folder
+    resources_folder_modification_time = max(resources_files_modification_times)
+
+    # resources modified more recently than lookup_table.json
+    if resources_folder_modification_time > lookup_table_modification_time:
+        return True
+    else:
+        return False
+
 def add_lookup_table_to_cache():
     """...WIP
 
@@ -364,34 +392,6 @@ def get_lookup_table_from_cache():
     with open("lookup_table.json", "r") as file:
         # Return lookup_table contents
         return json.load(file)
-
-def get_path(file_name, prefix=""):
-    """...WIP
-
-    TODO:
-        * write function docstring
-    """
-    return os.path.join(os.path.dirname(__file__), prefix+file_name)
-
-def is_lookup_table_outdated():
-    """...WIP"""
-    # last modification time of lookup_table.json
-    lookup_table_modification_time = os.path.getmtime("lookup_table.json")
-
-    # list of all file names in resources folder
-    resource_names = [file_name for file_name in os.listdir(get_path("resources"))]
-    # list of paths to all files in resources folder
-    resource_paths = [get_path(file_name, "resources/") for file_name in resource_names]
-    # list of last modification times for files in resources folder
-    resources_files_modification_times = [os.path.getmtime(path) for path in resource_paths]
-    # most recent modification time of a file in resources folder
-    resources_folder_modification_time = max(resources_files_modification_times)
-
-    # resources modified more recently than lookup_table.json
-    if resources_folder_modification_time > lookup_table_modification_time:
-        return True
-    else:
-        return False
 
 def run(args):
     """

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -384,11 +384,10 @@ def is_lookup_table_outdated():
         return False
 
 def add_lookup_table_to_cache():
-    """...WIP
+    """Saves nested dictionary of resources to a local file.
 
-    TODO:
-        * write function docstring
-        * follow single responsibility principle more closely
+    The nested dictionary corresponds to the return value of
+    get_all_resource_dicts, and is saved as lookup_table.json.
     """
     # Will contain all resource dictionaries
     lookup_table = get_all_resource_dicts()

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -230,7 +230,14 @@ def get_resource_dict(file_name, lower=False):
     return ret
 
 def get_all_resource_dicts():
-    """...WIP"""
+    """Returns collection of all dictionaries used in pipeline.run.
+
+    Return values:
+        * class <"dict">: Contains key-value pairs corresponding to
+            files in 'resources/'
+            * key: class <"str">
+            * val: class <"dict">
+    """
     # return value
     ret = {}
     ret["synonyms"] = get_resource_dict("SynLex.csv")
@@ -247,9 +254,7 @@ def get_all_resource_dicts():
     ret["inflection_exceptions"] = get_resource_dict("inflection-exceptions.csv", True)
     ret["stop_words"] = get_resource_dict("mining-stopwords.csv", True)
     ret["resource_terms_ID_based"] = get_resource_dict("CombinedResourceTerms.csv")
-    # TODO: reduce line length
     ret["resource_terms"] = {v:k for k,v in ret["resource_terms_ID_based"].items()}
-    # TODO: reduce line length
     ret["resource_terms_revised"] = {k.lower():v for k,v in ret["resource_terms"].items()}
     # TODO: clean this up if you can
     ret["resource_permutation_terms"] = {}

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -281,12 +281,14 @@ def load_lookup_table():
     TODO:
         * write function docstring
     """
+    # Path to resources folder
+    resources_path = os.path.join(os.path.dirname(__file__), "resources")
     # lookup_table.json exists
     if os.path.isfile("lookup_table.json"):
         # last modification time of lookup_table.json
         lookup_table_modification_time = os.path.getmtime("lookup_table.json")
         # list of all files in resources folder
-        resource_files = ["resources/"+file_name for file_name in os.listdir("resources")]
+        resource_files = ["resources/"+file_name for file_name in os.listdir(resources_path)]
         # list of all modification times for files in resource_files
         resource_files_modification_times = [os.path.getmtime(file) for file in resource_files]
         # most recent modification time of a file in resources folder

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -240,21 +240,37 @@ def get_all_resource_dicts():
     """
     # return value
     ret = {}
+    # Synonyms of resource terms
     ret["synonyms"] = get_resource_dict("SynLex.csv")
+    # Abbreviations of resource terms
     ret["abbreviations"] = get_resource_dict("AbbLex.csv")
+    # Abbreviations of resource terms, all lowercase
     ret["abbreviation_lower"] = get_resource_dict("AbbLex.csv", True)
+    # Non-english translations of resource terms
     ret["non_english_words"] = get_resource_dict("NefLex.csv")
+    # Non-english translations of resource terms, all lowercase
     ret["non_english_words_lower"] = get_resource_dict("NefLex.csv", True)
+    # Common misspellings of resource terms
     ret["spelling_mistakes"] = get_resource_dict("ScorLex.csv")
+    # Common misspellings of resource terms, all lowercase
     ret["spelling_mistakes_lower"] = get_resource_dict("ScorLex.csv", True)
+    # Terms corresponding to candidate processes
     ret["processes"] = get_resource_dict("candidateProcesses.csv")
+    # Terms corresponding to semantic taggings
     ret["qualities"] = get_resource_dict("SemLex.csv")
+    # Terms corresponding to semantic taggings, all lowercase
     ret["qualities_lower"] = get_resource_dict("SemLex.csv", True)
+    # Terms corresponding to wikipedia collocations
     ret["collocations"] = get_resource_dict("wikipediaCollocations.csv")
+    # Terms excluded from inflection treatment
     ret["inflection_exceptions"] = get_resource_dict("inflection-exceptions.csv", True)
+    # Constrained list of stop words considered to be meaningless
     ret["stop_words"] = get_resource_dict("mining-stopwords.csv", True)
+    # ID-resource combinations
     ret["resource_terms_ID_based"] = get_resource_dict("CombinedResourceTerms.csv")
+    # Swap keys and values in resource_terms_ID_based
     ret["resource_terms"] = {v:k for k,v in ret["resource_terms_ID_based"].items()}
+    # Convert keys in resource_terms to lowercase
     ret["resource_terms_revised"] = {k.lower():v for k,v in ret["resource_terms"].items()}
     # TODO: clean this up if you can
     ret["resource_permutation_terms"] = {}

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -430,10 +430,10 @@ def get_lookup_table_from_cache():
     is generated.
 
     Return values:
-        * class <"dict">: Contains key-value pairs corresponding to
+        * <class "dict">: Contains key-value pairs corresponding to
             files in "resources/"
-            * key: class <"str">
-            * val: class <"dict">
+            * key: <class "str">
+            * val: <class "dict">
     """
     # lookup_table.json exists
     if os.path.isfile(get_path("lookup_table.json")):
@@ -454,20 +454,37 @@ def get_lookup_table_from_cache():
         # Python 2
         else:
             # Return lookup_table contents in utf-8
-            return json.load(file, object_pairs_hook=str_hook)
+            return json.load(file, object_pairs_hook=unicode_to_utf_8)
 
-def str_hook(obj):
-    """...WIP
+def unicode_to_utf_8(decoded_pairs):
+    """object_pairs_hook to load json files without unicode values.
 
-    TODO:
-        * allows json to load lookup_table in utf-8 instead of unicode
-        * this is copy-pasted from https://stackoverflow.com/a/42377964
-            * figure out how this function works, and then comment and
-                rewrite it as needed
+    Arguments:
+        * decoded_pairs <class "list"> of <class "tuple">: Each tuple
+            contains a key-value pair from a json file being loaded
+    Return values:
+        * <class "dict">: This corresponds to a value from the JSON
+            file. Any unicode strings have been converted to utf-8.
+    Restrictiond:
+        * Should be called as the object_pairs_hook inside json.load
+        * Should only be called in Python 2
     """
-    return {k.encode('utf-8') if isinstance(k,unicode) else k :
-            v.encode('utf-8') if isinstance(v, unicode) else v
-            for k,v in obj}
+    # Return value
+    ret = {}
+    # Iterate over tuples in decoded_pairs
+    for key, val in decoded_pairs:
+        # key is unicode
+        if isinstance(key, unicode):
+            # Convert key to utf-8
+            key = key.encode("utf-8")
+        # val is unicode
+        if isinstance(val, unicode):
+            # Convert val to utf-8
+            val = val.encode("utf-8")
+        # Add key-val pair to ret
+        ret[key] = val
+    # Return ret
+    return ret
 
 def run(args):
     """

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -250,6 +250,17 @@ class MatchNotFoundError(Exception):
         """Return message when this class is raised as an exception."""
         return repr(self.message)
 
+def cache_resource_dict():
+    """...WIP
+
+    TODO:
+        * should go through each resource dictionary, and check if they are cached
+            * if not, call get_resource_dict for each missing dictionary
+        * implement function
+        * write function docstring
+    """
+    return
+
 def run(args):
     """
     Main text mining pipeline.

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -447,8 +447,27 @@ def get_lookup_table_from_cache():
         add_lookup_table_to_cache()
     # Open and read lookup_table.json
     with open(get_path("lookup_table.json"), "r") as file:
-        # Return lookup_table contents
-        return json.load(file)
+        # Python 3
+        if sys.version_info[0] >= 3:
+            # Return lookup_table contents in unicode
+            return json.load(file)
+        # Python 2
+        else:
+            # Return lookup_table contents in utf-8
+            return json.load(file, object_pairs_hook=str_hook)
+
+def str_hook(obj):
+    """...WIP
+
+    TODO:
+        * allows json to load lookup_table in utf-8 instead of unicode
+        * this is copy-pasted from https://stackoverflow.com/a/42377964
+            * figure out how this function works, and then comment and
+                rewrite it as needed
+    """
+    return {k.encode('utf-8') if isinstance(k,unicode) else k :
+            v.encode('utf-8') if isinstance(v, unicode) else v
+            for k,v in obj}
 
 def run(args):
     """

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -259,10 +259,12 @@ def update_lookup_table():
     """...WIP
 
     TODO:
-        * should compile and nest all resource dicts into one single dict
+        * should compile and nest all resource dicts into one single
+            dict
         * load dict into lookup_table.json
         * implement function
         * write function docstring
+        * follow single responsibility principle more closely
     """
     # Will contain all resource dictionaries
     lookup_table = {}
@@ -280,30 +282,24 @@ def load_lookup_table():
 
     TODO:
         * write function docstring
+        * follow single responsibility principle more closely
     """
     # lookup_table.json exists
-    if os.path.isfile("lookup_table.json"):
+    if os.path.isfile(get_path("lookup_table.json")):
         # last modification time of lookup_table.json
-        lookup_table_modification_time = os.path.getmtime("lookup_table.json")
+        lookup_table_modification_time = os.path.getmtime(get_path("lookup_table.json"))
 
         # Path to resources folder
         resources_path = os.path.join(os.path.dirname(__file__), "resources")
         # list of all file names in resources folder
-        resource_file_names = [file_name for file_name in os.listdir(resources_path)]
-        # list of paths to files in resources folder
-        resource_file_paths = [
-            os.path.join(
-                os.path.dirname(__file__),
-                "resources/" + file_name)
-            for file_name
-            in resource_file_names]
-        # list of all modification times for files in resource_file_paths
-        resource_files_modification_times = [
-            os.path.getmtime(file_path)
-            for file_path
-            in resource_file_paths]
+        resource_names = [file_name for file_name in os.listdir(get_path("resources"))]
+        # list of paths to all files in resources folder
+        resource_paths = [get_path(file_name, "resources/") for file_name in resource_names]
+        # list of last modification times for files in resources folder
+        resources_files_modification_times = [os.path.getmtime(path) for path in resource_paths]
         # most recent modification time of a file in resources folder
-        resources_folder_modification_time = max(resource_files_modification_times)
+        resources_folder_modification_time = max(resources_files_modification_times)
+        print(resources_folder_modification_time)
 
         # resources modified more recently than lookup_table.json
         if resources_folder_modification_time > lookup_table_modification_time:
@@ -316,10 +312,18 @@ def load_lookup_table():
     # Allow modifications to global variable lookup_table
     global lookup_table
     # Open and read lookup_table.json
-    with open("lookup_table.json", "r") as file:
+    with open(get_path("lookup_table.json"), "r") as file:
         # Write contents to lookup_table
         lookup_table = json.load(file)
     return
+
+def get_path(file_name, prefix=""):
+    """...WIP
+
+    TODO:
+        * write function docstring
+    """
+    return os.path.join(os.path.dirname(__file__), prefix+file_name)
 
 def run(args):
     """

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -17,9 +17,6 @@ import collections
 import json
 import os
 
-# Will contain all resource dictionaries
-lookup_table = {}
-
 logger = logging.getLogger("pipeline")
 logger.disabled = True
 
@@ -344,7 +341,7 @@ def add_lookup_table_to_cache():
         json.dump(lookup_table, file)
     return
 
-def load_lookup_table():
+def get_lookup_table_from_cache():
     """...WIP
 
     TODO:
@@ -357,18 +354,16 @@ def load_lookup_table():
     if os.path.isfile("lookup_table.json"):
         # lookup_table.json out of date
         if is_lookup_table_outdated():
+            # add new lookup table to cache
             add_lookup_table_to_cache()
     # lookup_table.json does not exist
     else:
-        # update lookup_table
+        # add lookup table to cache
         add_lookup_table_to_cache()
-    # Allow modifications to global variable lookup_table
-    global lookup_table
     # Open and read lookup_table.json
     with open("lookup_table.json", "r") as file:
-        # Write contents to lookup_table
-        lookup_table = json.load(file)
-    return
+        # Return lookup_table contents
+        return json.load(file)
 
 def get_path(file_name, prefix=""):
     """...WIP
@@ -412,8 +407,10 @@ def run(args):
     samplesSet = []
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
 
-    # Load global lookup_table variable from cache
-    load_lookup_table()
+    # This is a nested dictionary of all resource dictionaries used by
+    # run. It is retrieved from cache if possible. See
+    # get_lookup_table_from_cache docstring for details.
+    lookup_table = get_lookup_table_from_cache()
 
     # Output file Column Headings
     OUTPUT_FIELDS = [

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -280,6 +280,7 @@ def update_lookup_table():
     lookup_table["processes"] = get_resource_dict("candidateProcesses.csv")
     lookup_table["qualities"] = get_resource_dict("SemLex.csv")
     lookup_table["qualities_lower"] = get_resource_dict("SemLex.csv", True)
+    lookup_table["collocations"] = get_resource_dict("wikipediaCollocations.csv")
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
         # Write lookup_table in JSON format
@@ -354,9 +355,6 @@ def run(args):
     resource_terms_revised = {}
     resource_terms_ID_based = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-
-    # 17-Get all collocations (Wikipedia) from resource in a CSV file format and put in a dictionary to be used further
-    collocations = get_resource_dict("wikipediaCollocations.csv")
 
     # 18-Method to get all inflection exception words from resource in CSV file format -Needed to supercede the general inflection treatment
     inflection_exceptions = get_resource_dict("inflection-exceptions.csv", True)
@@ -767,11 +765,11 @@ def run(args):
                     "Permutation of Tokens in Bracketed Resource Term")
             # A full-term cleaned sample match with multi-word
             # collocation from Wikipedia exists.
-            elif cleaned_sample.lower() in collocations:
+            elif cleaned_sample.lower() in lookup_table["collocations"]:
                 # Term we found a full-term match for
                 matched_term = cleaned_sample.lower()
                 # Resource ID for matched_term
-                resource_id = collocations[matched_term]
+                resource_id = lookup_table["collocations"][matched_term]
                 # Update retained_tokens
                 retained_tokens.append(matched_term + ":"
                     + resource_id)

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -15,7 +15,7 @@ from pkg_resources import resource_filename, resource_listdir
 import logging
 import collections
 import json
-from os import path
+import os
 
 # Will contain all resource dictionaries
 lookup_table = {}
@@ -284,14 +284,24 @@ def load_lookup_table():
         * implement function
         * write function docstring
     """
+    # lookup_table.json exists
+    if os.path.isfile("lookup_table.json"):
+        # last modification time of lookup_table.json
+        lookup_table_modification_time = os.path.getmtime("lookup_table.json")
+        # list of all files in resources folder
+        resource_files = ["resources/"+file_name for file_name in os.listdir("resources")]
+        # list of all modification times for files in resource_files
+        resource_files_modification_times = [os.path.getmtime(file) for file in resource_files]
+        # most recent modification time of a file in resources folder
+        resources_folder_modification_time = max(resource_files_modification_times)
+        # resources modified more recently than lookup_table.json
+        if resources_folder_modification_time > lookup_table_modification_time:
+            # update lookup_table
+            update_lookup_table()
     # lookup_table.json does not exist
-    if not path.isfile("lookup_table.json"):
+    else:
         # update lookup_table
         update_lookup_table()
-    # set lookup_table_modification_time to last modification time of lookup_table.json
-    # set resources_modification_time to last modification time of resources folder
-    # if resources_modification_time > lookup_modification_time
-        # call update_lookup_table
     # Allow modifications to global variable lookup_table
     global lookup_table
     # Open and read lookup_table.json

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -544,8 +544,8 @@ def run(args):
                 cleaned_sample = lookup_table["abbreviation_lower"][cleaned_sample]
                 status_addendum.append("Cleaned Sample and Abbreviation-Acronym Treatment")
 
-            if (cleaned_sample in non_english_words.keys()):  # non English words taken care of
-                cleaned_sample = non_english_words[cleaned_sample]
+            if (cleaned_sample in lookup_table["non_english_words"].keys()):  # non English words taken care of
+                cleaned_sample = lookup_table["non_english_words"][cleaned_sample]
                 status_addendum.append("Cleaned Sample and Non English Language Words Treatment")
             elif (cleaned_sample in lookup_table["non_english_words_lower"].keys()):
                 cleaned_sample = lookup_table["non_english_words_lower"][cleaned_sample]

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -327,11 +327,25 @@ class MatchNotFoundError(Exception):
         return repr(self.message)
 
 def get_path(file_name, prefix=""):
-    """...WIP
+    """Returns path of file_name relative to pipeline.py.
 
-    TODO:
-        * write function docstring
+    Specifically, returns a path with the following pattern:
+
+        {path to pipeline.py}/{prefix}file_name
+
+    The path does not need to currently exist.
+
+    Arguments:
+        * file_name <class "str">: Name of file we want the relative
+            path to from pipeline.py.
+    Return values:
+        * <class "str">: Path to file_name
+    Optional arguments:
+        * prefix <class "str">: characters desired directly before
+            file_name in returned path
     """
+    # Return file_name appended to prefix and absolute path to
+    # pipeline.py.
     return os.path.join(os.path.dirname(__file__), prefix+file_name)
 
 def is_lookup_table_outdated():
@@ -342,7 +356,7 @@ def is_lookup_table_outdated():
 
     Return values:
         * <class "bool">: Indicates whether lookup_table.json is
-            outdated.
+            outdated
     Restrictions:
         * should only be called if lookup_table.json exists
     """

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -271,6 +271,9 @@ def update_lookup_table():
     # TODO: load each resource dictionary as seen in run, and add it to
     #       lookup_table.
     lookup_table["synonyms"] = get_resource_dict("SynLex.csv")
+    lookup_table["abbreviations"] = get_resource_dict("AbbLex.csv")
+    # TODO: this is not used
+    lookup_table["abbreviation_lower"] = get_resource_dict("AbbLex.csv", True)
     # Open and write to lookup_table.json
     with open("lookup_table.json", "w") as file:
         # Write lookup_table in JSON format
@@ -346,10 +349,6 @@ def run(args):
     resource_terms_revised = {}
     resource_terms_ID_based = {}
     suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
-
-    # 12-Get all abbreviation/acronyms from resource in CSV file format and put in a dictionary to be used further
-    abbreviations = get_resource_dict("AbbLex.csv")
-    abbreviation_lower = get_resource_dict("AbbLex.csv", True)
 
     # 13-Get all Non English Language words mappings from resource in CSV file format and put in a dictionary to be used further
     non_english_words = get_resource_dict("NefLex.csv")
@@ -520,8 +519,8 @@ def run(args):
             elif (lemma.lower() in spelling_mistakes_lower.keys()):
                 lemma = spelling_mistakes_lower[lemma.lower()]
                 status_addendum.append("Change Case and Spelling Correction Treatment")
-            if (lemma in abbreviations.keys()):  # Abbreviations, acronyms, foreign language words taken care of- need rule for abbreviation e.g. if lemma is Abbreviation
-                lemma = abbreviations[lemma]
+            if (lemma in lookup_table["abbreviations"].keys()):  # Abbreviations, acronyms, foreign language words taken care of- need rule for abbreviation e.g. if lemma is Abbreviation
+                lemma = lookup_table["abbreviations"][lemma]
                 status_addendum.append("Abbreviation-Acronym Treatment")
             elif (lemma.lower() in abbreviation_lower.keys()):
                 lemma = abbreviation_lower[lemma.lower()]
@@ -544,8 +543,8 @@ def run(args):
 
             cleaned_sample = re.sub(' +', ' ', cleaned_sample)  # Extra innner spaces removed from cleaned sample
 
-            if (cleaned_sample in abbreviations.keys()):  # NEED HERE AGAIN ? Abbreviations, acronyms, non English words taken care of- need rule for abbreviation
-                cleaned_sample = abbreviations[cleaned_sample]
+            if (cleaned_sample in lookup_table["abbreviations"].keys()):  # NEED HERE AGAIN ? Abbreviations, acronyms, non English words taken care of- need rule for abbreviation
+                cleaned_sample = lookup_table["abbreviations"][cleaned_sample]
                 status_addendum.append("Cleaned Sample and Abbreviation-Acronym Treatment")
             elif (cleaned_sample in abbreviation_lower.keys()):
                 cleaned_sample = abbreviation_lower[cleaned_sample]
@@ -917,8 +916,8 @@ def run(args):
                 setPerm = allPermutations(grm1)  # Gets the set of all possible permutations for this gram type chunks
                 for perm in setPerm:
                     grm = ' '.join(perm)
-                    if (grm in abbreviations.keys()):  # rule for abbreviation
-                        grm = abbreviations[grm]
+                    if (grm in lookup_table["abbreviations"].keys()):  # rule for abbreviation
+                        grm = lookup_table["abbreviations"][grm]
                         status_addendum.append("Abbreviation-Acronym Treatment")
                     if (grm in non_english_words.keys()):  # rule for abbreviation
                         grm = non_english_words[grm]
@@ -977,8 +976,8 @@ def run(args):
                 setPerm = allPermutations(grm1)  # Gets the set of all possible permutations for this gram type chunks
                 for perm in setPerm:
                     grm = ' '.join(perm)
-                    if (grm in abbreviations.keys()):  # rule for abbreviation
-                        grm = abbreviations[grm]
+                    if (grm in lookup_table["abbreviations"].keys()):  # rule for abbreviation
+                        grm = lookup_table["abbreviations"][grm]
                         status_addendum.append("Abbreviation-Acronym Treatment")
                     if (grm in non_english_words.keys()):  # rule for abbreviation
                         grm = non_english_words[grm]
@@ -1038,8 +1037,8 @@ def run(args):
                 for perm in setPerm:
                     grm = ' '.join(perm)
 
-                    if (grm in abbreviations.keys()):  # rule for abbreviation
-                        grm = abbreviations[grm]
+                    if (grm in lookup_table["abbreviations"].keys()):  # rule for abbreviation
+                        grm = lookup_table["abbreviations"][grm]
                         status_addendum.append("Abbreviation-Acronym Treatment")
                     if (grm in non_english_words.keys()):  # rule for abbreviation
                         grm = non_english_words[grm]
@@ -1109,8 +1108,8 @@ def run(args):
                 setPerm = allPermutations(grm1)  # Gets the set of all possible permutations for this gram type chunks
                 for perm in setPerm:
                     grm = ' '.join(perm)
-                    if (grm in abbreviations.keys()):  # rule for abbreviation
-                        grm = abbreviations[grm]
+                    if (grm in lookup_table["abbreviations"].keys()):  # rule for abbreviation
+                        grm = lookup_table["abbreviations"][grm]
                         status_addendum.append("Abbreviation-Acronym Treatment")
                     if (grm in non_english_words.keys()):  # rule for abbreviation
                         grm = non_english_words[grm]
@@ -1179,8 +1178,8 @@ def run(args):
                 grmTokens = word_tokenize(grm.lower())
                 localTrigger = False
 
-                if (grm in abbreviations.keys()):  # rule for abbreviation
-                    grm = abbreviations[grm]
+                if (grm in lookup_table["abbreviations"].keys()):  # rule for abbreviation
+                    grm = lookup_table["abbreviations"][grm]
                     status_addendum.append("Abbreviation-Acronym Treatment")
                 if (grm in non_english_words.keys()):  # rule for abbreviation
                     grm = non_english_words[grm]

--- a/lexmapr/tests/test_pipeline.py
+++ b/lexmapr/tests/test_pipeline.py
@@ -37,7 +37,6 @@ class TestPipelineMethods(unittest.TestCase):
         * test_preProcess
         * test_find_between_r()
         * test_find_left_r()
-        * test_addSuffix()
         * test_allPermutations()
         * test_combi()
         * test_punctuationTreatment()


### PR DESCRIPTION
This addresses #26.

We could use pickle to save the dictionaries into separate files, for use in subsequent runs.

I did some spot performance comparisons between retrieving dictionaries from .pkl files and reading them from the .csv files (as is currently done), and reading from .pkl files was faster. Particularly for larger dictionaries, and for dictionaries that were generated from other dictionaries--such as resource_permutation_terms.

JSON is another option for storing dictionaries as files, but seems to be slower.