### PR TITLE
[WIP] Pull find_full_term_match out of pipeline.run.

### DIFF
--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -967,12 +967,10 @@ def run(args):
                     + full_term_match["all_match_terms_with_resource_ids"])
             # Tokenize sample
             sample_tokens = word_tokenize(sample.lower())
-            # Iterate over tokens
-            for token in sample_tokens:
-                # Add token to covered_tokens
-                covered_tokens.append(token)
-                # Remove token from remaining_tokens
-                remaining_tokens.remove(token)
+            # Add all tokens to covered_tokens
+            [covered_tokens.append(token) for token in sample_tokens]
+            # Remove all tokens from remaining_tokens
+            [remaining_tokens.remove(token) for token in sample_tokens]
             # Set trigger to True
             trigger = True
         # Full-term match not found

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -17,24 +17,6 @@ import collections
 import json
 import os
 
-# Suffixes used in FoodOn
-suffixes = [
-    "(food source)",
-    "(vegetable) food product",
-    "vegetable food product",
-    "nut food product",
-    "fruit food product",
-    "seafood product",
-    "meat food product",
-    "plant fruit food product",
-    "plant food product",
-    "(food product)",
-    "food product",
-    "plant (food source)",
-    "product",
-    "(whole)",
-    "(deprecated)"
-    ]
 # This will be a nested dictionary of all resource dictionaries used by
 # run. It is retrieved from cache if possible. See
 # get_lookup_table_from_cache docstring for details.
@@ -486,7 +468,7 @@ def unicode_to_utf_8(decoded_pairs):
     # Return ret
     return ret
 
-def find_full_term_match(sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens):
+def find_full_term_match(suffixes, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens):
     """Retrieve an annotated, full-term match for a sample.
 
     The sample matched, along with multiple resource
@@ -797,6 +779,24 @@ def run(args):
     Main text mining pipeline.
     """
     punctuations = ['-', '_', '(', ')', ';', '/', ':', '%']  # Current punctuations for basic treatment
+    # Suffixes used in FoodOn
+    suffixes = [
+        "(food source)",
+        "(vegetable) food product",
+        "vegetable food product",
+        "nut food product",
+        "fruit food product",
+        "seafood product",
+        "meat food product",
+        "plant fruit food product",
+        "plant food product",
+        "(food product)",
+        "food product",
+        "plant (food source)",
+        "product",
+        "(whole)",
+        "(deprecated)"
+        ]
     covered_tokens = []
     remainingAllTokensSet = []
     remainingTokenSet = []
@@ -969,7 +969,7 @@ def run(args):
         #---------------------------STARTS APPLICATION OF RULES-----------------------------------------------
         try:
             # Find full-term match for sample
-            full_term_match = find_full_term_match(sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens)
+            full_term_match = find_full_term_match(suffixes, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens)
             # Write to all headers
             if args.format == "full":
                 fw.write("\t" + full_term_match["matched_term"] + "\t"

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -463,7 +463,7 @@ def unicode_to_utf_8(decoded_pairs):
     # Return ret
     return ret
 
-def find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_addendum, covered_tokens, remaining_tokens):
+def find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_addendum):
     """Retrieve an annotated, full-term match for a sample.
 
     The sample matched, along with multiple resource
@@ -520,14 +520,6 @@ def find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_
                             cleaned_sample output annotations
                 * status_addendum
                     * ...
-                * covered_tokens
-                    * covered_tokens is not relevant to output in
-                        full-term matches
-                    * eliminate from code
-                * remaining_tokens
-                    * remaining_tokens is not relevant to output in
-                        full-term matches
-                    * eliminate from code
     """
     # Tokens to retain for all_match_terms_with_resource_ids
     retained_tokens = []
@@ -732,14 +724,6 @@ def find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_
         "match_status_macro_level": "Full Term Match",
         "match_status_micro_level": str(list(final_status)),
     })
-    # Tokenize sample
-    sample_tokens = word_tokenize(sample.lower())
-    # Iterate over tokens
-    for token in sample_tokens:
-        # Add token to covered_tokens
-        covered_tokens.append(token)
-        # Remove token from remaining_tokens
-        remaining_tokens.remove(token)
     # Return
     return ret
 
@@ -967,7 +951,7 @@ def run(args):
         #---------------------------STARTS APPLICATION OF RULES-----------------------------------------------
         try:
             # Find full-term match for sample
-            full_term_match = find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_addendum, covered_tokens, remaining_tokens)
+            full_term_match = find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_addendum)
             # Write to all headers
             if args.format == "full":
                 fw.write("\t" + full_term_match["matched_term"] + "\t"
@@ -981,6 +965,14 @@ def run(args):
             else:
                 fw.write("\t" + full_term_match["matched_term"] + "\t"
                     + full_term_match["all_match_terms_with_resource_ids"])
+            # Tokenize sample
+            sample_tokens = word_tokenize(sample.lower())
+            # Iterate over tokens
+            for token in sample_tokens:
+                # Add token to covered_tokens
+                covered_tokens.append(token)
+                # Remove token from remaining_tokens
+                remaining_tokens.remove(token)
             # Set trigger to True
             trigger = True
         # Full-term match not found

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -17,11 +17,6 @@ import collections
 import json
 import os
 
-# This will be a nested dictionary of all resource dictionaries used by
-# run. It is retrieved from cache if possible. See
-# get_lookup_table_from_cache docstring for details.
-lookup_table = {}
-
 logger = logging.getLogger("pipeline")
 logger.disabled = True
 
@@ -468,7 +463,7 @@ def unicode_to_utf_8(decoded_pairs):
     # Return ret
     return ret
 
-def find_full_term_match(suffixes, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens):
+def find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_addendum, covered_tokens, remaining_tokens):
     """Retrieve an annotated, full-term match for a sample.
 
     The sample matched, along with multiple resource
@@ -773,8 +768,9 @@ def run(args):
     samplesList = []
     samplesSet = []
 
-    # Fill global variable lookup_table
-    global lookup_table
+    # This will be a nested dictionary of all resource dictionaries used by
+    # run. It is retrieved from cache if possible. See
+    # get_lookup_table_from_cache docstring for details.
     lookup_table = get_lookup_table_from_cache()
 
     # Output file Column Headings
@@ -937,7 +933,7 @@ def run(args):
         #---------------------------STARTS APPLICATION OF RULES-----------------------------------------------
         try:
             # Find full-term match for sample
-            full_term_match = find_full_term_match(suffixes, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens)
+            full_term_match = find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_addendum, covered_tokens, remaining_tokens)
             # Write to all headers
             if args.format == "full":
                 fw.write("\t" + full_term_match["matched_term"] + "\t"

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -489,27 +489,6 @@ def find_full_term_match(suffixes, sample, cleaned_sample, status_addendum, cove
         * Must be called inside run
 
     TODO:
-        * move this function out of run
-            * The reason it is currently in run is because we
-                need access to several variables that are local
-                to run
-            * There are two potential solutions:
-                * Pass all local variables to this function
-                    * Unreasonable, there are too many
-                * Create a class with the following:
-                    * Constructer with all variables relevant
-                        to application rules
-                    * get_resource_dict
-                        * Likely called in constructer
-                    * find_full_term_match
-                    * MatchNotFoundError
-                    * This is the most reasonable solution
-                    * Before beginning the design and
-                        construction of a class, we may want to
-                        do the following:
-                            * Get find_full_term_match working
-                            * Abstract component matching
-                                * May fit in new class
         * simplify change-of-case treatments as follows:
             * resource dictionaries only contain lower-case
                 words
@@ -518,6 +497,8 @@ def find_full_term_match(suffixes, sample, cleaned_sample, status_addendum, cove
             * check if sample != sample.lower()
                 * if true, add change-of-case treatment to
                     status addendum
+        * reduce number of parameters
+            * create a helper function to generate cleaned sample
     """
     # Tokens to retain for all_match_terms_with_resource_ids
     retained_tokens = []
@@ -579,26 +560,21 @@ def find_full_term_match(suffixes, sample, cleaned_sample, status_addendum, cove
         # Permutation corresponding to matched_term
         matched_permutation = lookup_table["resource_terms_ID_based"][resource_id]
         # Update retained_tokens
-        retained_tokens.append(matched_permutation + ":"
-            + resource_id)
+        retained_tokens.append(matched_permutation + ":" + resource_id)
         # Update status_addendum
-        status_addendum.append(
-            "Permutation of Tokens in Resource Term")
+        status_addendum.append("Permutation of Tokens in Resource Term")
     # Full-term match with permutation of bracketed resource term
     elif sample.lower() in lookup_table["resource_bracketed_permutation_terms"]:
         # Term we found a permutation for
         matched_term = sample.lower()
         # Resource ID for matched_term's permutation
-        resource_id =\
-            lookup_table["resource_bracketed_permutation_terms"][matched_term]
+        resource_id = lookup_table["resource_bracketed_permutation_terms"][matched_term]
         # Permutation corresponding to matched_term
         matched_permutation = lookup_table["resource_terms_ID_based"][resource_id]
         # Update retained_tokens
-        retained_tokens.append(matched_permutation + ":"
-            + resource_id)
+        retained_tokens.append(matched_permutation + ":" + resource_id)
         # Update status_addendum
-        status_addendum.append(
-            "Permutation of Tokens in Bracketed Resource Term")
+        status_addendum.append("Permutation of Tokens in Bracketed Resource Term")
     # Full-term cleaned sample match without any treatment
     elif cleaned_sample.lower() in lookup_table["resource_terms"]:
         # Term with we found a full-term match for
@@ -630,27 +606,22 @@ def find_full_term_match(suffixes, sample, cleaned_sample, status_addendum, cove
         # Permutation corresponding to matched_term
         matched_permutation = lookup_table["resource_terms_ID_based"][resource_id]
         # Update retained_tokens
-        retained_tokens.append(matched_permutation + ":"
-            + resource_id)
+        retained_tokens.append(matched_permutation + ":" + resource_id)
         # Update status_addendum
-        status_addendum.append(
-            "Permutation of Tokens in Resource Term")
+        status_addendum.append("Permutation of Tokens in Resource Term")
     # Full-term cleaned sample match with permutation of
     # bracketed resource term.
     elif cleaned_sample.lower() in lookup_table["resource_bracketed_permutation_terms"]:
         # Term we found a permutation for
         matched_term = cleaned_sample.lower()
         # Resource ID for matched_term's permutation
-        resource_id =\
-            lookup_table["resource_bracketed_permutation_terms"][matched_term]
+        resource_id = lookup_table["resource_bracketed_permutation_terms"][matched_term]
         # Permutation corresponding to matched_term
         matched_permutation = lookup_table["resource_terms_ID_based"][resource_id]
         # Update retained_tokens
-        retained_tokens.append(matched_permutation + ":"
-            + resource_id)
+        retained_tokens.append(matched_permutation + ":" + resource_id)
         # Update status_addendum
-        status_addendum.append(
-            "Permutation of Tokens in Bracketed Resource Term")
+        status_addendum.append("Permutation of Tokens in Bracketed Resource Term")
     # A full-term cleaned sample match with multi-word
     # collocation from Wikipedia exists.
     elif cleaned_sample.lower() in lookup_table["collocations"]:
@@ -659,25 +630,24 @@ def find_full_term_match(suffixes, sample, cleaned_sample, status_addendum, cove
         # Resource ID for matched_term
         resource_id = lookup_table["collocations"][matched_term]
         # Update retained_tokens
-        retained_tokens.append(matched_term + ":"
-            + resource_id)
+        retained_tokens.append(matched_term + ":" + resource_id)
         # Update status_addendum
         status_addendum.append(
-            "New Candidadte Terms -"
-            + "validated with Wikipedia Based Collocation Resource"
+            "New Candidadte Terms -validated with Wikipedia Based Collocation Resource"
         )
     # Full-term match not found
     else:
+        resource_terms_revised = lookup_table["resource_terms_revised"]
         # Find all suffixes that when appended to sample, are
         # in resource_terms_revised.
-        matched_suffixes =\
-            [s for s in suffixes
-                if sample+" "+s in lookup_table["resource_terms_revised"]]
+        matched_suffixes = (
+            [s for s in suffixes if sample+" "+s in resource_terms_revised]
+        )
         # Find all suffixes that when appended to cleaned
         # sample, are in resource_terms_revised.
-        matched_clean_suffixes =\
-            [s for s in suffixes
-                if cleaned_sample+" "+s in lookup_table["resource_terms_revised"]]
+        matched_clean_suffixes = (
+            [s for s in suffixes if cleaned_sample+" "+s in resource_terms_revised]
+        )
         # A full-term match with change of resource and suffix
         # addition exists.
         if matched_suffixes:
@@ -687,42 +657,40 @@ def find_full_term_match(suffixes, sample, cleaned_sample, status_addendum, cove
             # Term we add a suffix to
             matched_term = sample.lower()
             # Resource ID for matched_term
-            resource_id = lookup_table["resource_terms_revised"][term_with_suffix]
+            resource_id = resource_terms_revised[term_with_suffix]
             # Update retained_tokens
-            retained_tokens.append(term_with_suffix + ":"
-                + resource_id)
+            retained_tokens.append(term_with_suffix + ":" + resource_id)
             # Update status_addendum
             status_addendum.append(
                 "[Change of Case of Resource and Suffix Addition- "
                 + matched_suffixes[0]
-                + " to the Input]")
+                + " to the Input]"
+            )
         # A full-term cleaned sample match with change of resource and
         # suffix addition exists.
         elif matched_clean_suffixes:
             # Term with first suffix in suffixes that provides
             # a full-term match.
-            term_with_suffix = cleaned_sample.lower() + " "\
-                + matched_clean_suffixes[0]
+            term_with_suffix = cleaned_sample.lower() + " " + matched_clean_suffixes[0]
             # Term we cleaned and added a suffix to
             matched_term = sample.lower()
             # Resource ID for matched_term
-            resource_id = lookup_table["resource_terms_revised"][term_with_suffix]
+            resource_id = resource_terms_revised[term_with_suffix]
             # Update retained_tokens
-            retained_tokens.append(term_with_suffix + ":"
-                + resource_id)
+            retained_tokens.append(term_with_suffix + ":" + resource_id)
             # Update status_addendum
             status_addendum.append(
-                "[CleanedSample-"
-                + "Change of Case of Resource and Suffix Addition- "
+                "[CleanedSample-Change of Case of Resource and Suffix Addition- "
                 + matched_clean_suffixes[0]
-                + " to the Input]")
+                + " to the Input]"
+            )
         # No full-term match possible with suffixes either
         else:
-            raise MatchNotFoundError("Full-term match not found for: "
-                + sample)
+            raise MatchNotFoundError("Full-term match not found for: " + sample)
 
     # If we reach here, we had a full-term match with a
     # non-empty sample.
+
     # status_addendum without duplicates
     final_status = set(status_addendum)
     # Update ret

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -517,6 +517,8 @@ def find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_
                 * suffixes
                     * maybe we can stick this and punctuations in
                         lookup_table?
+                    * suffixes and punctuations could also be global
+                        variables
                 * cleaned_sample
                     * if we can make a helper function that generates
                         cleaned_sample, we can simply call it
@@ -530,7 +532,11 @@ def find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_
                             "cleaned sample" to the beginning of
                             cleaned_sample output annotations
                 * status_addendum
-                    * ...
+                    * Call to some sort of a preprocessing method to
+                        get changes to status_addendum that occur
+                        before find_full_term_match
+                        * A function for component matching could have
+                            the same call
     """
     # Tokens to retain for all_match_terms_with_resource_ids
     retained_tokens = []

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -17,6 +17,25 @@ import collections
 import json
 import os
 
+# Suffixes used in FoodOn
+suffixes = [
+    "(food source)",
+    "(vegetable) food product",
+    "vegetable food product",
+    "nut food product",
+    "fruit food product",
+    "seafood product",
+    "meat food product",
+    "plant fruit food product",
+    "plant food product",
+    "(food product)",
+    "food product",
+    "plant (food source)",
+    "product",
+    "(whole)",
+    "(deprecated)"
+    ]
+
 logger = logging.getLogger("pipeline")
 logger.disabled = True
 
@@ -463,7 +482,7 @@ def unicode_to_utf_8(decoded_pairs):
     # Return ret
     return ret
 
-def find_full_term_match(lookup_table, suffixes, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens):
+def find_full_term_match(lookup_table, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens):
     """Retrieve an annotated, full-term match for a sample.
 
     The sample matched, along with multiple resource
@@ -781,7 +800,6 @@ def run(args):
     samplesDict = collections.OrderedDict()
     samplesList = []
     samplesSet = []
-    suffixes = ["(food source)","(vegetable) food product","vegetable food product", "nut food product","fruit food product","seafood product","meat food product", "plant fruit food product","plant food product", "(food product)","food product","plant (food source)","product","(whole)","(deprecated)"]
 
     # This is a nested dictionary of all resource dictionaries used by
     # run. It is retrieved from cache if possible. See
@@ -948,7 +966,7 @@ def run(args):
         #---------------------------STARTS APPLICATION OF RULES-----------------------------------------------
         try:
             # Find full-term match for sample
-            full_term_match = find_full_term_match(lookup_table, suffixes, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens)
+            full_term_match = find_full_term_match(lookup_table, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens)
             # Write to all headers
             if args.format == "full":
                 fw.write("\t" + full_term_match["matched_term"] + "\t"

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -463,7 +463,7 @@ def unicode_to_utf_8(decoded_pairs):
     # Return ret
     return ret
 
-def find_full_term_match():
+def find_full_term_match(lookup_table, suffixes, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens):
     """Retrieve an annotated, full-term match for a sample.
 
     The sample matched, along with multiple resource
@@ -948,7 +948,7 @@ def run(args):
         #---------------------------STARTS APPLICATION OF RULES-----------------------------------------------
         try:
             # Find full-term match for sample
-            full_term_match = find_full_term_match()
+            full_term_match = find_full_term_match(lookup_table, suffixes, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens)
             # Write to all headers
             if args.format == "full":
                 fw.write("\t" + full_term_match["matched_term"] + "\t"

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -750,6 +750,11 @@ class MatchNotFoundError(Exception):
 
     Instance variables:
         * message <class "str">
+
+    TODO:
+        * do we need this class?
+            * perhaps the try clause that relied on this exception
+                could instead use KeyError
     """
 
     def __init__(self, message):

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -493,7 +493,41 @@ def find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_
                 * if true, add change-of-case treatment to
                     status addendum
         * reduce number of parameters
-            * create a helper function to generate cleaned sample
+            * what we need, and makes sense as a parameter for this
+                type of function
+                * sample
+                * lookup_table
+                    * Rather than make lookup_table into a global
+                        variable, we should pass it as a parameter
+                        * It will allow us to more easily separate
+                            pipeline.py functions into different files
+                            in the future (if we choose to do so)
+            * what does not look good as a parameter
+                * suffixes
+                    * maybe we can stick this and punctuations in
+                        lookup_table?
+                * cleaned_sample
+                    * if we can make a helper function that generates
+                        cleaned_sample, we can simply call it
+                    * we can also call find_full_term_match in run with
+                        sample, and then if nothing is found, with
+                        cleaned_sample
+                        * this would involve adjusting the outputted
+                            annotations of run, so sample and
+                            cleaned_sample outputs are more similar,
+                            and we just have to add something like
+                            "cleaned sample" to the beginning of
+                            cleaned_sample output annotations
+                * status_addendum
+                    * ...
+                * covered_tokens
+                    * covered_tokens is not relevant to output in
+                        full-term matches
+                    * eliminate from code
+                * remaining_tokens
+                    * remaining_tokens is not relevant to output in
+                        full-term matches
+                    * eliminate from code
     """
     # Tokens to retain for all_match_terms_with_resource_ids
     retained_tokens = []

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -35,6 +35,10 @@ suffixes = [
     "(whole)",
     "(deprecated)"
     ]
+# This will be a nested dictionary of all resource dictionaries used by
+# run. It is retrieved from cache if possible. See
+# get_lookup_table_from_cache docstring for details.
+lookup_table = {}
 
 logger = logging.getLogger("pipeline")
 logger.disabled = True
@@ -482,7 +486,7 @@ def unicode_to_utf_8(decoded_pairs):
     # Return ret
     return ret
 
-def find_full_term_match(lookup_table, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens):
+def find_full_term_match(sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens):
     """Retrieve an annotated, full-term match for a sample.
 
     The sample matched, along with multiple resource
@@ -801,9 +805,8 @@ def run(args):
     samplesList = []
     samplesSet = []
 
-    # This is a nested dictionary of all resource dictionaries used by
-    # run. It is retrieved from cache if possible. See
-    # get_lookup_table_from_cache docstring for details.
+    # Fill global variable lookup_table
+    global lookup_table
     lookup_table = get_lookup_table_from_cache()
 
     # Output file Column Headings
@@ -966,7 +969,7 @@ def run(args):
         #---------------------------STARTS APPLICATION OF RULES-----------------------------------------------
         try:
             # Find full-term match for sample
-            full_term_match = find_full_term_match(lookup_table, sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens)
+            full_term_match = find_full_term_match(sample, cleaned_sample, status_addendum, covered_tokens, remaining_tokens)
             # Write to all headers
             if args.format == "full":
                 fw.write("\t" + full_term_match["matched_term"] + "\t"

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -1223,7 +1223,7 @@ def run(args):
                     if (sampleRevisedWithSuffix in lookup_table["resource_terms_revised"].keys() and not localTrigger):  # Not trigger true is used here -reason
                         # resourceId = resourceRevisedTermsDict[sampleRevisedWithSuffix]
                         partialMatchedList.append(sampleRevisedWithSuffix)
-                        status_addendum.append("Suffix Addition- " + suffixString + " to the Input")
+                        status_addendum.append("Suffix Addition- " + suffix + " to the Input")
                         for eachTkn in grmTokens:
                             covered_tokens.append(eachTkn)
                             if eachTkn in remaining_tokens:

--- a/lexmapr/pipeline.py
+++ b/lexmapr/pipeline.py
@@ -473,15 +473,26 @@ def find_full_term_match(sample, lookup_table, suffixes, cleaned_sample, status_
 
     Also returns relevant information for empty samples.
 
+    Arguments:
+        * sample <"str">: Name of sample we want to find a full-term
+            match for.
+        * lookup_table <"dict">: Nested dictionary containing resources
+            needed to find a full_term_match. See
+            get_lookup_table_from_cache for details.
+        * suffixes <"list"> of <"str">: Suffixes to append to sample we
+            want to consider when looking for a full_term_match.
+        * cleaned_sample <"str">: Vleaned version of sample we will
+            use to look for a full-term match, if one for sample does
+            not exist.
+        * status_addendum <"list"> of <"str">: Modifications made to
+            sample in preprocessing.
     Return values:
-        * class <"dict">: Contains all relevant annotations for
+        * <"dict">: Contains all relevant annotations for
             output headers.
-            * key: class <"str">
-            * val: class <"str">
+            * key <"str">
+            * val <"str">
     Exceptions raised:
         * MatchNotFoundError: Full-term match not found
-    Restrictions:
-        * Must be called inside run
 
     TODO:
         * simplify change-of-case treatments as follows:

--- a/lexmapr/resources/suffixes.csv
+++ b/lexmapr/resources/suffixes.csv
@@ -1,0 +1,16 @@
+Suffixes
+(food source)
+(vegetable) food product
+vegetable food product
+nut food product
+fruit food product
+seafood product
+meat food product
+plant fruit food product
+plant food product
+(food product)
+food product
+plant (food source)
+product
+(whole)
+(deprecated)


### PR DESCRIPTION
This addresses #9 .

Having a large function like find_full_term_match inside pipeline.run makes the code cluttered, less modularized and more difficult to read. Therefore, we will pull find_full_term_match out of pipeline.run.